### PR TITLE
Add option for Google Site Verification

### DIFF
--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -21,3 +21,5 @@ max_toc_heading_level: 6
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: false
+
+google_site_verification: dstbao8TVS^DRVDS&rv76

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -16,6 +16,10 @@
 
     <link rel="canonical" href="<%= config[:tech_docs][:host] %><%= current_page.url %>">
 
+    <% if config[:tech_docs][:google_site_verification] %>
+      <meta name="google-site-verification" content="<%= config[:tech_docs][:google_site_verification] %>" />
+    <% end %>
+
     <%= stylesheet_link_tag :print, media: 'print' %>
     <%= javascript_include_tag :application %>
   </head>


### PR DESCRIPTION
This is used by GOV.UK Pay (https://github.com/alphagov/pay-tech-docs/pull/60) and Registers (https://github.com/alphagov/registers-tech-docs/pull/15).

Once https://github.com/alphagov/tech-docs-gem/pull/2 is merged we'll need to add it to that too.