### PR TITLE
Allow redirects to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Unreleased
 
-New feature: you can now show a block at the bottom of the page that links to
+### New feature: redirects
+
+You can now specify redirects in the frontmatter and `config/tech-docs.yml`.
+
+You can use this when you change a page URL.
+
+More info:
+
+- https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#redirects
+- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#old_paths
+
+### New feature: contribution banner
+
+You can now show a block at the bottom of the page that links to
 the page source on GitHub, so readers can easily contribute back to the documentation.
 
 https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#show_contribution_banner

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,3 +113,13 @@ Your repository. Required if `show_contribution_banner` is true.
 ```yaml
 github_repo: alphagov/example-repo
 ```
+
+## `redirects`
+
+A list of redirects, from old to new location.
+
+```yaml
+redirects:
+  /old-page.html: /new-page.html
+  /another/old-page.html: /another/new-page.html
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,10 +116,11 @@ github_repo: alphagov/example-repo
 
 ## `redirects`
 
-A list of redirects, from old to new location.
+A list of redirects, from old to new location. Use this to set up external
+redirects or if [setting `old_paths` in the frontmatter](docs/frontmatter.md#old_paths) doesn't work.
 
 ```yaml
 redirects:
-  /old-page.html: /new-page.html
+  /old-page.html: https://example.org/something-else.html
   /another/old-page.html: /another/new-page.html
 ```

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -1,0 +1,14 @@
+# Available frontmatter
+
+## `old_paths`
+
+Any paths of pages that should redirect to this page.
+
+Example:
+
+```yaml
+---
+old_paths:
+  - /some-old-page.html
+---
+```

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -27,3 +27,6 @@ google_site_verification: dstbao8TVS^DRVDS&rv76
 show_contribution_banner: true
 
 github_repo: alphagov/example-repo
+
+redirects:
+  /something/old.html: /index.html

--- a/example/source/index.html.md.erb
+++ b/example/source/index.html.md.erb
@@ -1,5 +1,7 @@
 ---
 title: GOV.UK Documentation Example
+old_paths:
+ - /something/old-as-well.html
 ---
 
 # Hello, World!

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -8,6 +8,7 @@ require 'middleman-syntax'
 
 require 'nokogiri'
 
+require 'govuk_tech_docs/redirects'
 require 'govuk_tech_docs/table_of_contents/helpers'
 require 'govuk_tech_docs/contribution_banner'
 require 'govuk_tech_docs/tech_docs_html_renderer'
@@ -52,5 +53,13 @@ module GovukTechDocs
     context.page '/*.xml', layout: false
     context.page '/*.json', layout: false
     context.page '/*.txt', layout: false
+
+    context.ready do
+      redirects = GovukTechDocs::Redirects.new(context).redirects
+
+      redirects.each do |from, to|
+        context.redirect from, to
+      end
+    end
   end
 end

--- a/lib/govuk_tech_docs/redirects.rb
+++ b/lib/govuk_tech_docs/redirects.rb
@@ -1,0 +1,39 @@
+module GovukTechDocs
+  class Redirects
+    LEADING_SLASH = %r[\A\/]
+
+    def initialize(context)
+      @context = context
+    end
+
+    def redirects
+      all_redirects = redirects_from_config + redirects_from_frontmatter
+
+      all_redirects.map do |from, to|
+        # Middleman needs paths without leading slashes
+        [from.sub(LEADING_SLASH, ''), to: to.sub(LEADING_SLASH, '')]
+      end
+    end
+
+  private
+
+    attr_reader :context
+
+    def redirects_from_config
+      context.config[:tech_docs][:redirects].to_a
+    end
+
+    def redirects_from_frontmatter
+      reds = []
+      context.sitemap.resources.each do |page|
+        next unless page.data.old_paths
+
+        page.data.old_paths.each do |old_path|
+          reds << [old_path, page.path]
+        end
+      end
+
+      reds
+    end
+  end
+end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "The tech docs template" do
     then_there_is_a_heading
     then_there_is_a_source_footer
 
+    and_redirects_are_working
+    and_frontmatter_redirects_are_working
+
     when_i_view_a_proxied_page
     then_there_is_another_source_footer
   end
@@ -48,5 +51,15 @@ RSpec.describe "The tech docs template" do
     ].each do |url|
       expect(page).to have_link(nil, href: url)
     end
+  end
+
+  def and_redirects_are_working
+    visit '/something/old.html'
+    expect(page.body).to match '<link rel="canonical" href="/" />'
+  end
+
+  def and_frontmatter_redirects_are_working
+    visit '/something/old-as-well.html'
+    expect(page.body).to match '<link rel="canonical" href="/" />'
   end
 end


### PR DESCRIPTION
This adds a feature to allow redirects to be configured:

- in `config/tech-docs.yml`
- in the frontmatter of the page

It is extracted from GOV.UK's developer docs, which uses [a separate YAML file](https://github.com/alphagov/govuk-developer-docs/blob/ea18ff348d3a3c974e8a4ff67b174ca6d556eaa6/data/redirects.yml) to map redirects.

Part of the Q4 GOV.UK 🔥 firebreak: https://trello.com/c/QbspvRc2
