### PR TITLE
Raise a better error for pages without a H1 tag

### DIFF
--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -9,6 +9,11 @@ module GovukTechDocs
     module Helpers
       def table_of_contents(html, max_level: nil)
         headings = HeadingsBuilder.new(html).headings
+
+        if headings.none? { |heading| heading.size == 1 }
+          raise "No H1 tag found. You have to at least add one H1 heading to the page."
+        end
+
         tree = HeadingTreeBuilder.new(headings).tree
         HeadingTreeRenderer.new(tree, max_level: max_level).html
       end

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -8,12 +8,9 @@ module GovukTechDocs
   module TableOfContents
     module Helpers
       def table_of_contents(html, max_level: nil)
-        HeadingTreeRenderer.new(
-          HeadingTreeBuilder.new(
-            HeadingsBuilder.new(html).headings
-          ).tree,
-          max_level: max_level
-        ).html
+        headings = HeadingsBuilder.new(html).headings
+        tree = HeadingTreeBuilder.new(headings).tree
+        HeadingTreeRenderer.new(tree, max_level: max_level).html
       end
     end
   end

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -73,5 +73,13 @@ describe GovukTechDocs::TableOfContents::Helpers do
 
       expect(subject.table_of_contents(html).strip).to eq(expected_table_of_contents.strip)
     end
+
+    it 'builds a table of contents from HTML without an h1' do
+      html = %{
+        <h2 id="apples">Apples</h3>
+      }
+
+      expect { subject.table_of_contents(html).strip }.to raise_error(RuntimeError)
+    end
   end
 end


### PR DESCRIPTION
 It often happens that people forget to add a h1 tag. The headings parsing code can't handle this and crashes. Helpfully, it will tell the user:

```
undefined method `depth' for nil:NilClass
```

This commit changes the behaviour to raise a more informative error, namely:

```
No H1 tag found. You have to at least add one H1 heading to the page.
```

Even better would be to avoid the error altogether, but I'm having a lot of trouble understanding the recursive nature of `HeadingTreeBuilder`.

Closes https://github.com/alphagov/tech-docs-template/issues/140.

Part of the Q4 GOV.UK 🔥 firebreak: https://trello.com/c/QbspvRc2
