### PR TITLE
Implement an optional "contribution banner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
+## Unreleased
+
+New feature: you can now show a block at the bottom of the page that links to
+the page source on GitHub, so readers can easily contribute back to the documentation.
+
+https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#show_contribution_banner
+
 ## 1.1.0
 
 You can now specify `google_site_verification` in tech-docs.yml. You can use
 this to verify your site in Google Webmaster tools.
 
-https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#google_site_verification 
+https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#google_site_verification
 
 ## 1.0.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,3 +92,24 @@ Adds a [Google Site Verification code](https://support.google.com/webmasters/ans
 ```yaml
 google_site_verification: TvDTuyvdstyusadrCSDrctyd
 ```
+
+## `show_contribution_banner`
+
+Show a block at the bottom of the page that links to the page source, so readers
+can easily contribute back to the documentation. If turned on `github_repo` is
+required.
+
+Off by default.
+
+```yaml
+show_contribution_banner: true
+github_repo: alphagov/example-repo
+```
+
+## `github_repo`
+
+Your repository. Required if `show_contribution_banner` is true.
+
+```yaml
+github_repo: alphagov/example-repo
+```

--- a/example/config.rb
+++ b/example/config.rb
@@ -1,3 +1,9 @@
 require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
+
+ignore 'templates/*'
+
+proxy '/a-proxied-page.html', 'templates/proxy_template.html', locals: {
+  title: 'I am a title'
+}

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -23,3 +23,7 @@ max_toc_heading_level: 6
 prevent_indexing: false
 
 google_site_verification: dstbao8TVS^DRVDS&rv76
+
+show_contribution_banner: true
+
+github_repo: alphagov/example-repo

--- a/example/source/templates/proxy_template.html.md
+++ b/example/source/templates/proxy_template.html.md
@@ -1,0 +1,8 @@
+---
+title: Proxied page
+source_url: http://example.org/source.md
+---
+
+# Proxied page
+
+This is a proxied page.

--- a/lib/assets/stylesheets/_core.scss
+++ b/lib/assets/stylesheets/_core.scss
@@ -26,6 +26,7 @@ $desktop-breakpoint: 992px !default;
 @import "modules/header";
 @import "modules/phase-banner";
 @import "modules/skip-link";
+@import "modules/contribution-banner";
 @import "modules/technical-documentation";
 @import "modules/toc";
 

--- a/lib/assets/stylesheets/modules/_contribution-banner.scss
+++ b/lib/assets/stylesheets/modules/_contribution-banner.scss
@@ -1,0 +1,22 @@
+.contribution-banner {
+  padding: 0;
+  max-width: 40em;
+  margin-top: $gutter * 2;
+  margin-left: $gutter-half;
+  margin-right: $gutter-half;
+
+  @include media(tablet) {
+    margin-left: $gutter + 2px;
+    margin-right: $gutter + 2px;
+  }
+
+  a {
+    margin-right: $gutter-half;
+  }
+
+  li {
+    display: inline-block;
+    list-style: none;
+    margin: 2px 0;
+  }
+}

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -9,6 +9,7 @@ require 'middleman-syntax'
 require 'nokogiri'
 
 require 'govuk_tech_docs/table_of_contents/helpers'
+require 'govuk_tech_docs/contribution_banner'
 require 'govuk_tech_docs/tech_docs_html_renderer'
 require 'govuk_tech_docs/unique_identifier_extension'
 require 'govuk_tech_docs/unique_identifier_generator'
@@ -45,6 +46,7 @@ module GovukTechDocs
 
     context.helpers do
       include GovukTechDocs::TableOfContents::Helpers
+      include GovukTechDocs::ContributionBanner
     end
 
     context.page '/*.xml', layout: false

--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -1,0 +1,52 @@
+module GovukTechDocs
+  # Helper included
+  module ContributionBanner
+    def source_urls
+      SourceUrls.new(current_page, config)
+    end
+  end
+
+  class SourceUrls
+    attr_reader :current_page, :config
+
+    def initialize(current_page, config)
+      @current_page = current_page
+      @config = config
+    end
+
+    def view_source_url
+      override_from_page || source_from_yaml_file || source_from_file
+    end
+
+    def report_issue_url
+      "#{repo_url}/issues/new?labels=bug&title=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+    end
+
+    def repo_url
+      "https://github.com/#{config[:tech_docs][:github_repo]}"
+    end
+
+  private
+
+    # If a `page` local exists, see if it has a `source_url`. This is used by the
+    # pages that are created by the proxy system because they can't use frontmatter
+    def override_from_page
+      locals.key?(:page) ? locals[:page].try(:source_url) : false
+    end
+
+    # In the frontmatter we can specify a `source_url`. Use this if the actual
+    # source of the page is in another GitHub repo.
+    def source_from_yaml_file
+      current_page.data.source_url
+    end
+
+    # As the last fallback link to the source file in this repository.
+    def source_from_file
+      "#{repo_url}/blob/master/source/#{current_page.file_descriptor[:relative_path]}"
+    end
+
+    def locals
+      current_page.metadata[:locals]
+    end
+  end
+end

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -53,6 +53,14 @@
             <%= yield %>
           </main>
 
+          <% if config[:tech_docs][:show_contribution_banner] %>
+            <ul class="contribution-banner">
+              <li><%= link_to "View source", source_urls.view_source_url %></li>
+              <li><%= link_to "Report problem", source_urls.report_issue_url %></li>
+              <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
+            </ul>
+          <% end %>
+
           <%= partial "layouts/footer" %>
         </div>
       </div>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe "The tech docs template" do
     when_the_site_is_created
     and_i_visit_the_homepage
     then_there_is_a_heading
+    then_there_is_a_source_footer
+
+    when_i_view_a_proxied_page
+    then_there_is_another_source_footer
   end
 
   def when_the_site_is_created
@@ -22,5 +26,27 @@ RSpec.describe "The tech docs template" do
 
   def then_there_is_a_heading
     expect(page).to have_css 'h1', text: 'Hello, World!'
+  end
+
+  def then_there_is_a_source_footer
+    %w[
+      https://github.com/alphagov/example-repo/blob/master/source/index.html.md.erb
+      https://github.com/alphagov/example-repo
+    ].each do |url|
+      expect(page).to have_link(nil, href: url)
+    end
+  end
+
+  def when_i_view_a_proxied_page
+    visit '/a-proxied-page.html'
+  end
+
+  def then_there_is_another_source_footer
+    %w[
+      http://example.org/source.md
+      https://github.com/alphagov/example-repo
+    ].each do |url|
+      expect(page).to have_link(nil, href: url)
+    end
   end
 end


### PR DESCRIPTION
This implements an optional new feature, the "contribution banner". It's a small banner under the content of the page that links to:

- The source of the current page on GitHub, so that people can easily propose changes to the content
- A pre-filled GitHub issue, so that people can notify the owners of problems with the content
- The GitHub repository

The feature is optional and needs to be turned on explicitly in `tech-docs.yml`.

This is extracted from the GOV.UK developer docs, where it has been in use for around a year.

Part of the Q4 GOV.UK 🔥 firebreak: https://trello.com/c/QbspvRc2

## Screenshots

<img width="1317" alt="screen shot 2018-04-04 at 13 51 36" src="https://user-images.githubusercontent.com/233676/38308528-4879e9a0-380f-11e8-8853-082b685f1eba.png">
<img width="570" alt="screen shot 2018-04-04 at 13 51 41" src="https://user-images.githubusercontent.com/233676/38308529-489a17fc-380f-11e8-8584-f459ed58195e.png">

