### PR TITLE
Improve the browse / page title

### DIFF
--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -25,7 +25,7 @@ module GovukTechDocs
     end
 
     def browser_title
-      "#{page_title} | #{site_name}"
+      [page_title, site_name].select(&:present?).uniq.join(' | ')
     end
 
     def canonical_url

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -1,4 +1,36 @@
 RSpec.describe GovukTechDocs::MetaTags do
+  describe '#browser_title' do
+    it 'combines the page title and service name' do
+      browser_title = generate_title(site_name: "Test Site", page_title: "The Title")
+
+      expect(browser_title).to eql("The Title | Test Site")
+    end
+
+    it 'does not duplicate the page title' do
+      browser_title = generate_title(site_name: "My documentation site", page_title: "My documentation site")
+
+      expect(browser_title).to eql("My documentation site")
+    end
+
+    it 'does not show an empty page title' do
+      browser_title = generate_title(site_name: "My documentation site", page_title: nil)
+
+      expect(browser_title).to eql("My documentation site")
+    end
+
+    def generate_title(site_name:, page_title:)
+      config = generate_config(
+        service_name: site_name,
+      )
+
+      current_page = double("current_page",
+        data: double("page_frontmatter", description: "The description.", title: page_title),
+        metadata: { locals: {} })
+
+      GovukTechDocs::MetaTags.new(config, current_page).browser_title
+    end
+  end
+
   describe '#tags' do
     it 'returns all the extra meta tags' do
       config = generate_config(
@@ -48,14 +80,14 @@ RSpec.describe GovukTechDocs::MetaTags do
 
       expect(tags["og:title"]).to eql("The local variable title.")
     end
+  end
 
-    def generate_config(config = {})
-      {
-        tech_docs: {
-          host: "https://www.example.org",
-          service_name: "Test Site",
-        }.merge(config)
-      }
-    end
+  def generate_config(config = {})
+    {
+      tech_docs: {
+        host: "https://www.example.org",
+        service_name: "Test Site",
+      }.merge(config)
+    }
   end
 end


### PR DESCRIPTION
This makes the browser title nice even if the page title is the same as the site name (as can happen on homepages) and if the page title is empty.

Follow up to https://github.com/alphagov/tech-docs-gem/pull/11.

---

Part of the Q4 GOV.UK 🔥 firebreak: https://trello.com/c/QbspvRc2

