### PR TITLE
Don't crash when `host` isn't set

### DIFF
--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -53,7 +53,7 @@ module GovukTechDocs
     end
 
     def host
-      config[:tech_docs][:host]
+      config[:tech_docs][:host].to_s
     end
 
     def locals

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe GovukTechDocs::MetaTags do
 
       expect(tags["og:title"]).to eql("The local variable title.")
     end
+
+    it 'works even when no config is set' do
+      current_page = double("current_page",
+        data: double("page_frontmatter", description: "The description.", title: "The Title"),
+        url: "/foo.html",
+        metadata: { locals: { title: "The local variable title." } })
+
+      config = { tech_docs: {} }
+
+      tags = GovukTechDocs::MetaTags.new(config, current_page).tags
+
+      expect(tags).to be_a(Hash)
+    end
   end
 
   def generate_config(config = {})


### PR DESCRIPTION
Since https://github.com/alphagov/tech-docs-gem/pull/11 the template crashes when `host` isn't specified in config/tech-docs.yml.

This makes sure that we don't crash.

cc @selfthinker 