### PR TITLE
Allow options to be passed to GovukTechDocs.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+You can now pass options into `GovukTechDocs.configure` for the `livereload`
+extension.
+
+```rb
+GovukTechDocs.configure(self, livereload: { js_host: 'localhost' })
+```
+
 ## 1.2.0
 
 ### New feature: redirects

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -21,7 +21,12 @@ require 'govuk_tech_docs/unique_identifier_extension'
 require 'govuk_tech_docs/unique_identifier_generator'
 
 module GovukTechDocs
-  def self.configure(context)
+  # Configure the tech docs template
+  #
+  # @param options [Hash]
+  # @option options [Hash] livereload Options to pass to the `livereload`
+  #   extension. Hash with symbols as keys.
+  def self.configure(context, options = {})
     context.activate :autoprefixer
     context.activate :sprockets
     context.activate :syntax
@@ -39,7 +44,7 @@ module GovukTechDocs
 
     # Reload the browser automatically whenever files change
     context.configure :development do
-      activate :livereload
+      activate :livereload, options[:livereload].to_h
     end
 
     context.configure :build do


### PR DESCRIPTION
This can be used to set up the `livereload` extension to work in Docker.

cc @arnau