### PR TITLE
Determine active page by considering parent too

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -110,4 +110,14 @@ title: My beautiful page
 ---
 ```
 
+## `parent`
+
+The page that should be highlighted as ‘active’ in the navigation.
+
+```yaml
+---
+parent: shaving-yaks.html
+---
+```
+
 [mm]: https://middlemanapp.com/basics/frontmatter

--- a/example/source/child-of-expired-page.html.md
+++ b/example/source/child-of-expired-page.html.md
@@ -1,0 +1,8 @@
+---
+title: This is a child of expired page
+parent: expired-page.html
+---
+
+# This is a child of expired page
+
+Expired page should highlight in the navigation.

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -70,6 +70,14 @@ module GovukTechDocs
       def format_date(date)
         date.strftime('%-e %B %Y')
       end
+
+      def active_page(page_path)
+        [
+          page_path == "/" && current_page.path == "index.html",
+          ("/" + current_page.path) == page_path,
+          current_page.data.parent != nil && ("/" + current_page.data.parent.to_s) == page_path,
+        ].any?
+      end
     end
 
     context.page '/*.xml', layout: false

--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -31,9 +31,9 @@
 
         <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" aria-hidden="true">
           <ul>
-            <% config[:tech_docs][:header_links].each do |title, url| %>
-              <li<% if url == current_page.url %> class="active"<% end %>>
-                <a href="<%= url %>">
+            <% config[:tech_docs][:header_links].each do |title, path| %>
+              <li<% if active_page(path) %> class="active"<% end %>>
+                <a href="<%= path %>">
                   <%= title %>
                 </a>
               </li>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "The tech docs template" do
     and_i_visit_the_homepage
     then_there_is_a_heading
     then_there_is_a_source_footer
+    then_the_page_highlighted_in_the_navigation_is("Documentation")
 
     and_there_are_proper_meta_tags
     and_redirects_are_working
@@ -18,6 +19,12 @@ RSpec.describe "The tech docs template" do
 
     when_i_view_a_proxied_page
     then_there_is_another_source_footer
+
+    when_i_view_expired_page
+    then_the_page_highlighted_in_the_navigation_is("Expired page")
+
+    when_i_view_child_of_expired_page
+    then_the_page_highlighted_in_the_navigation_is("Expired page")
   end
 
   def when_the_site_is_created
@@ -46,6 +53,10 @@ RSpec.describe "The tech docs template" do
     end
   end
 
+  def then_the_page_highlighted_in_the_navigation_is(link_label)
+    expect(page.find('li.active a').text).to eq(link_label)
+  end
+
   def when_i_view_a_proxied_page
     visit '/a-proxied-page.html'
   end
@@ -67,5 +78,13 @@ RSpec.describe "The tech docs template" do
   def and_frontmatter_redirects_are_working
     visit '/something/old-as-well.html'
     expect(page.body).to match '<link rel="canonical" href="/" />'
+  end
+
+  def when_i_view_expired_page
+    visit '/expired-page.html'
+  end
+
+  def when_i_view_child_of_expired_page
+    visit '/child-of-expired-page.html'
   end
 end


### PR DESCRIPTION
Currently the logic that works out which page to highlight as ‘active’ in the top navigation is quite naïve (only compares URLs directly).

This commit makes it a bit smarter so that a page can define its `parent`, then the navigation will highlight the matching ‘parent’ navigation item.

Adapted from: https://github.com/alphagov/govuk-developer-docs/commit/7e5ac5144d87aebf28ca98297b4250c307416c8e