### PR TITLE
Add basic font and background colour

### DIFF
--- a/lib/assets/stylesheets/_core.scss
+++ b/lib/assets/stylesheets/_core.scss
@@ -34,6 +34,8 @@ $desktop-breakpoint: 992px !default;
 @import "accessibility";
 
 html, body {
+  color: $text-colour;
+  background-color: $page-colour;
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
If basic colours are not set and someone changes colour settings in their browser, this can result in e.g. an unreadable black text on a black background.
When I open https://alphagov.github.io/tech-docs-manual/ in my Firefox (which I have set to yellow text on a black background but with override set to "never"), it looks like this:

<img width="1105" alt="" src="https://user-images.githubusercontent.com/108893/39316692-b2a15070-4971-11e8-9144-6d2cdf7330e4.png">

This fixes that by adding `colour` and `background-color` to the body.