### PR TITLE
Allow ‘parent’ page to be an absolute URL

### DIFF
--- a/example/source/child-of-expired-page.html.md
+++ b/example/source/child-of-expired-page.html.md
@@ -1,6 +1,6 @@
 ---
 title: This is a child of expired page
-parent: expired-page.html
+parent: /expired-page.html
 ---
 
 # This is a child of expired page

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -75,7 +75,7 @@ module GovukTechDocs
         [
           page_path == "/" && current_page.path == "index.html",
           ("/" + current_page.path) == page_path,
-          current_page.data.parent != nil && ("/" + current_page.data.parent.to_s) == page_path,
+          current_page.data.parent != nil && current_page.data.parent.to_s == page_path,
         ].any?
       end
     end


### PR DESCRIPTION
On Notify our tech docs are hosted at docs.notifications.service.gov.uk but the parent of the documentation page is at www.notifications.service.gov.uk

By automatically prepending the `parent` config with a `/` it prevents us setting a header link whose `href` is an absolute URL (ie www.notifications…) as the active one.