### PR TITLE
Release version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased
+## 1.3.0
+
+Version 1.3.0 contains accessibility fixes (#20) and a fix to make the
+site more robust when certain options aren't set in the configs (#17).
+
+### New feature: passing options to `GovukTechDocs.configure`
 
 You can now pass options into `GovukTechDocs.configure` for the `livereload`
 extension.
@@ -8,6 +13,18 @@ extension.
 ```rb
 GovukTechDocs.configure(self, livereload: { js_host: 'localhost' })
 ```
+
+See PR #18.
+
+### New feature: page parents
+
+You can now specify a page’s parent in its frontmatter. This affects
+which item is selected in the navigation.
+
+More info:
+
+- https://github.com/alphagov/tech-docs-gem/pull/19
+- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#parent
 
 ## 1.2.0
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.2.0".freeze
+  VERSION = "1.3.0".freeze
 end


### PR DESCRIPTION
## 1.3.0

### New feature: page parents

You can now specify a page’s parent in its frontmatter. This affects which item is selected in the navigation.

More info:

- https://github.com/alphagov/tech-docs-gem/pull/19
- https://github.com/alphagov/tech-docs-gem/pull/23
- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#parent