### PR TITLE
Set page with anchor point in google analytics

### DIFF
--- a/lib/source/layouts/_analytics.erb
+++ b/lib/source/layouts/_analytics.erb
@@ -9,6 +9,7 @@
   ga('set', 'anonymizeIp', true);
   ga('set', 'displayFeaturesTask', null);
   ga('set', 'transport', 'beacon');
+  ga('set', 'page', location.pathname+location.search+location.hash);
   ga('send', 'pageview');
   </script>
 <% end %>


### PR DESCRIPTION
Ensure we can send the entry point to tech docs by getting the anchor tag ID from the URL

# After
<img width="799" alt="screen shot 2018-05-04 at 12 39 37" src="https://user-images.githubusercontent.com/3071606/39626829-7b3e5f94-4f9b-11e8-9df4-80f24ecc2e6b.png">
