### PR TITLE
GTD-56: Add GA event tracking if a user loads a page with a fragment ID that doesn't exist

### DIFF
--- a/lib/assets/javascripts/_analytics.js
+++ b/lib/assets/javascripts/_analytics.js
@@ -19,6 +19,20 @@
     };
   };
 
+  function catchBrokenFragmentLinks() {
+    var fragment = window.location.hash;
+    var $target = $(fragment);
+    if(!$target.get(0)) {
+      ga(
+        'send',
+        'event',
+        'Broken fragment ID', // Event Category
+        'pageview', // Event Action
+        window.location.pathname + fragment // Event Label
+      );
+    }
+  }
+
   $(document).on('ready', function() {
     if (typeof ga === 'undefined') {
       return;
@@ -27,5 +41,6 @@
     $('.technical-documentation a').on('click', linkTrackingEventHandler('inTextClick'));
     $('.header a').on('click', linkTrackingEventHandler('topNavigationClick'));
     $('.toc a').on('click', linkTrackingEventHandler('tableOfContentsNavigationClick'));
+    catchBrokenFragmentLinks();
   });
 })(jQuery);


### PR DESCRIPTION
This is a way for content authors to track old links that haven't been updated to point to the new page.