### PR TITLE
Use fork of `middleman-search`

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'govuk_tech_docs', path: '..'
+gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'


### PR DESCRIPTION
I'm not entirely sure of the reasons why the fork has to be used but according to @lewisnyman this is required for now.