### PR TITLE
Replace default stop words filter with a custom function.

### DIFF
--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -40,6 +40,7 @@
         success: function(data) {
           s.lunrData = data;
           s.lunrIndex = lunr.Index.load(s.lunrData.index);
+          replaceStopWordFilter();
           $(document).trigger('lunrIndexLoaded');
         }
       });
@@ -84,7 +85,6 @@
           results.push(s.lunrData.docs[item.ref]);
         }
       });
-
       return results;
     }
 
@@ -175,6 +175,135 @@
       .attr('aria-hidden', 'true');
       $html.removeClass('has-search-results-open');
     }
+
+    function replaceStopWordFilter() {
+      // Replace the default stopWordFilter as it excludes useful words like
+      // 'get'
+      // See: https://lunrjs.com/docs/stop_word_filter.js.html#line43
+      s.lunrIndex.pipeline.remove(lunr.stopWordFilter);
+      s.lunrIndex.pipeline.add(s.govukStopWorldFilter);
+    }
+
+   this.govukStopWorldFilter = lunr.generateStopWordFilter([
+      'a',
+      'able',
+      'about',
+      'across',
+      'after',
+      'all',
+      'almost',
+      'also',
+      'am',
+      'among',
+      'an',
+      'and',
+      'any',
+      'are',
+      'as',
+      'at',
+      'be',
+      'because',
+      'been',
+      'but',
+      'by',
+      'can',
+      'cannot',
+      'could',
+      'dear',
+      'did',
+      'do',
+      'does',
+      'either',
+      'else',
+      'ever',
+      'every',
+      'for',
+      'from',
+      'got',
+      'had',
+      'has',
+      'have',
+      'he',
+      'her',
+      'hers',
+      'him',
+      'his',
+      'how',
+      'however',
+      'i',
+      'if',
+      'in',
+      'into',
+      'is',
+      'it',
+      'its',
+      'just',
+      'least',
+      'let',
+      'like',
+      'likely',
+      'may',
+      'me',
+      'might',
+      'most',
+      'must',
+      'my',
+      'neither',
+      'no',
+      'nor',
+      'not',
+      'of',
+      'off',
+      'often',
+      'on',
+      'only',
+      'or',
+      'other',
+      'our',
+      'own',
+      'rather',
+      'said',
+      'say',
+      'says',
+      'she',
+      'should',
+      'since',
+      'so',
+      'some',
+      'than',
+      'that',
+      'the',
+      'their',
+      'them',
+      'then',
+      'there',
+      'these',
+      'they',
+      'this',
+      'tis',
+      'to',
+      'too',
+      'twas',
+      'us',
+      'wants',
+      'was',
+      'we',
+      'were',
+      'what',
+      'when',
+      'where',
+      'which',
+      'while',
+      'who',
+      'whom',
+      'why',
+      'will',
+      'with',
+      'would',
+      'yet',
+      'you',
+      'your'
+    ])
   };
 
   // Polyfill includes


### PR DESCRIPTION
We had some feedback during testing that some search terms were not returning any results. After some digging, I found out that lunr.js implements a [stop word filter](https://en.m.wikipedia.org/wiki/Stop_words) by default. 

The default list includes useful words like 'get', especially in API docs. This PR reimplemented the stop word list so we can maintain a custom list.

Initially I've only removed 'get' but we might find a few more to remove with wider testing.