### PR TITLE
Search Google Analytics tracking

### DIFF
--- a/lib/assets/javascripts/_analytics.js
+++ b/lib/assets/javascripts/_analytics.js
@@ -42,5 +42,17 @@
     $('.header a').on('click', linkTrackingEventHandler('topNavigationClick'));
     $('.toc a').on('click', linkTrackingEventHandler('tableOfContentsNavigationClick'));
     catchBrokenFragmentLinks();
+
+    // Borrowed from:
+    // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
+    window.stripPIIFromString = function (string) {
+      var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+      var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
+      var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+      var stripped = string.replace(EMAIL_PATTERN, '[email]')
+      .replace(DATE_PATTERN, '[date]')
+      .replace(POSTCODE_PATTERN, '[postcode]');
+      return stripped
+    }
   });
 })(jQuery);

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -67,6 +67,20 @@
         $searchInput.focus();
         hideResults();
       });
+
+      // Attach analytics events to search result clicks
+      if(window.ga) {
+        $searchResults.on('click', '.search-result__title a', function() {
+          var href = $(this).attr('href');
+          ga('send', {
+            hitType: 'event',
+            eventCategory: 'Search result',
+            eventAction: 'click',
+            eventLabel: href,
+            transport: 'beacon'
+          });
+        });
+      }
     }
 
     function getResults(query) {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -15,6 +15,8 @@
     var $searchResultsWrapper;
     var $searchResultsClose;
     var results;
+    var query;
+    var queryTimer;
     var maxSearchEntries = 10;
 
     this.start = function start($element) {
@@ -46,12 +48,16 @@
       // Search functionality on search text input
       $searchInput.on('input', function (e) {
         e.preventDefault();
-        var query = $(this).val();
+        query = $(this).val();
         s.search(query, function(r) {
           results = r;
           renderResults(query);
           updateTitle();
         });
+        if(window.ga) {
+          window.clearTimeout(queryTimer);
+          queryTimer = window.setTimeout(sendQueryToAnalytics, 1000);
+        }
       });
 
       // Set focus on the first search result instead of submiting the search
@@ -180,6 +186,16 @@
       $searchResultsWrapper.removeClass('is-open')
       .attr('aria-hidden', 'true');
       $html.removeClass('has-search-results-open');
+    }
+
+    function sendQueryToAnalytics() {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: 'Search query',
+        eventAction: 'type',
+        eventLabel: query,
+        transport: 'beacon'
+      });
     }
   };
 

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -197,6 +197,9 @@
     }
 
     function sendQueryToAnalytics() {
+      if(query === '') {
+        return;
+      }
       ga('send', {
         hitType: 'event',
         eventCategory: 'Search query',

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -200,11 +200,12 @@
       if(query === '') {
         return;
       }
+      var stripped = window.stripPIIFromString(query)
       ga('send', {
         hitType: 'event',
         eventCategory: 'Search query',
         eventAction: 'type',
-        eventLabel: query,
+        eventLabel: stripped,
         transport: 'beacon'
       });
     }


### PR DESCRIPTION
This PR adds event tracking on search result clicks and on search terms, there's a wait time of a second after a user has finished typing before an event is sent. This might be too low and we might need to increase this once we have real usage. 