### PR TITLE
Remove stopword filter from Lunr index generation in middleman-search.

### DIFF
--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -102,6 +102,10 @@ module GovukTechDocs
           content: { boost: 50, store: true },
           url:     { index: false, store: true },
         }
+
+        search.pipeline_remove = [
+          'stopWordFilter'
+        ]
       end
     end
   end


### PR DESCRIPTION
After some testing with registers I found that alphagov/tech-docs-gem#38 was only half a fix.
alphagov/registers-tech-docs#109. As the lunr index is pre-generated by middleman-search, we also need to remove the stopwordfilter there to return useful results for `get`.

I've added this config option in the alphagov fork. See: alphagov/middleman-search#1

