### PR TITLE
Adds custom token separator for the search index

### DIFF
--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -106,6 +106,8 @@ module GovukTechDocs
         search.pipeline_remove = [
           'stopWordFilter'
         ]
+
+        search.tokenizer_separator = '/[\s\-/]+/'
       end
     end
   end


### PR DESCRIPTION
Similar to #41, I found that we needed to be able to override the default lunr tokenizer separator. This fixes the issue found in alphagov/registers-tech-docs#109 - queries for `json` now return results that includes `application/json`

I've added this config option in the middleman-search alphagov fork. See: alphagov/middleman-search#2

For more background info: olivernn/lunr.js#365