### PR TITLE
Remove duplicate search result snippets

### DIFF
--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -31,7 +31,7 @@
         var $topLevelItem = $($topLevelItems[i]);
         var $heading = $topLevelItem.find('> a');
         var $listing = $topLevelItem.find('> ul');
-        var id = 'toc-' + $heading.text().toLowerCase().replace(' ', '-')
+        var id = 'toc-' + $heading.text().toLowerCase().replace(' ', '-');
         // Only add collapsible functionality if there are children.
         if ($listing.length == 0) {
           continue;

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -149,9 +149,10 @@
           break;
         }
 
-        var containsMark = sentences[i].includes('mark>');
-        if (containsMark) {
-          selectedSentences.push(sentences[i].trim());
+        var sentence = sentences[i].trim();
+        var containsMark = sentence.includes('mark>');
+        if (containsMark && (selectedSentences.indexOf(sentence) == -1)) {
+          selectedSentences.push(sentence);
         }
       }
       if(selectedSentences.length > 0) {


### PR DESCRIPTION
Fixes alphagov/tech-docs-template#167

As found in alphagov/registers-tech-docs#109 If you had a search term appearing on the same page in the exact same sentence, you end up with multiple identical snippers, which is not useful.
