### PR TITLE
Release version 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.5.1
+
+### Correct fork of middleman in example project
+
+The example gem project now uses alphagov/middleman-search. This prevents `bundle exec middleman serve` from crashing.
+
+More info:
+- https://github.com/alphagov/tech-docs-gem/pull/35
+
+### Accessibility improvements
+
+Accessibility improvements to search, collapsible navigation, and the logo.
+
+More info:
+- https://github.com/alphagov/tech-docs-gem/pull/36
+- https://github.com/alphagov/tech-docs-gem/pull/33
+
+### Search result improvements
+
+The search indexing pipeline has been tweaked to provide expected results. The display of the search results has also been
+
+More info:
+- https://github.com/alphagov/tech-docs-gem/pull/37
+- https://github.com/alphagov/tech-docs-gem/pull/38
+- https://github.com/alphagov/tech-docs-gem/pull/41
+- https://github.com/alphagov/tech-docs-gem/pull/42
+- https://github.com/alphagov/tech-docs-gem/pull/43
+
 ## 1.5.0
 
 ### New feature: Search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ More info:
 
 The search indexing pipeline has been tweaked to provide expected results. The display of the search results has also been
 
+If you're using search then you'll need to add this line to your project `Gemfile`:
+
+```
+gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'
+```
+
 More info:
 - https://github.com/alphagov/tech-docs-gem/pull/37
 - https://github.com/alphagov/tech-docs-gem/pull/38

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.5.0".freeze
+  VERSION = "1.5.1".freeze
 end


### PR DESCRIPTION
## 1.5.1

### Correct fork of middleman in example project

The example gem project now uses alphagov/middleman-search. This prevents `bundle exec middleman serve` from crashing.

More info:
- https://github.com/alphagov/tech-docs-gem/pull/35

### Accessibility improvements

Accessibility improvements to search, collapsible navigation, and the logo.

More info:
- https://github.com/alphagov/tech-docs-gem/pull/36
- https://github.com/alphagov/tech-docs-gem/pull/33

### Search result improvements

The search indexing pipeline has been tweaked to provide expected results. The display of the search results has also been

More info:
- https://github.com/alphagov/tech-docs-gem/pull/37
- https://github.com/alphagov/tech-docs-gem/pull/38
- https://github.com/alphagov/tech-docs-gem/pull/41
- https://github.com/alphagov/tech-docs-gem/pull/42
- https://github.com/alphagov/tech-docs-gem/pull/43
