### PR TITLE
Add two new config options for review handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Additional configuration options for review system
+
+`default_owner_slack` and `owner_slack_workspace` are now configurable for use within the review system.
+
+More info:
+- https://github.com/alphagov/tech-docs-gem/pull/47
+
 ## 1.5.0
 
 ### New feature: Search

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,3 +156,21 @@ Define a path to an Open API V3 spec file. This can be a relative file path or a
 ```yaml
 api_path: ./source/pets.yml
 ```
+
+## `default_owner_slack`
+
+The default Slack user or channel name to show as the owner of a piece of
+content. Can be overridden using the `owner_slack` frontmatter config option.
+
+```yaml
+default_owner_slack: '#owner'
+```
+
+## `owner_slack_workspace`
+
+The Slack workspace name used when linking to the Slack owner of a piece of
+content.
+
+```yaml
+owner_slack_workspace: gds
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,16 @@ Define a path to an Open API V3 spec file. This can be a relative file path or a
 api_path: ./source/pets.yml
 ```
 
+## `owner_slack_workspace`
+
+The Slack workspace name used when linking to the Slack owner of a piece of
+content. If not provided, the owner of a piece of content (channel or user)
+won't be linked.
+
+```yaml
+owner_slack_workspace: gds
+```
+
 ## `default_owner_slack`
 
 The default Slack user or channel name to show as the owner of a piece of
@@ -164,13 +174,4 @@ content. Can be overridden using the `owner_slack` frontmatter config option.
 
 ```yaml
 default_owner_slack: '#owner'
-```
-
-## `owner_slack_workspace`
-
-The Slack workspace name used when linking to the Slack owner of a piece of
-content.
-
-```yaml
-owner_slack_workspace: gds
 ```

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -43,3 +43,7 @@ redirects:
   /something/old.html: /index.html
 
 api_path: source/pets.yml
+
+# Optional global settings for the page review process
+owner_slack_workspace: gds
+default_owner_slack: '#2nd-line'

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -70,7 +70,7 @@ module GovukTechDocs
       end
 
       def current_page_review
-        @current_page_review ||= GovukTechDocs::PageReview.new(current_page)
+        @current_page_review ||= GovukTechDocs::PageReview.new(current_page, config)
       end
 
       def format_date(date)

--- a/lib/govuk_tech_docs/page_review.rb
+++ b/lib/govuk_tech_docs/page_review.rb
@@ -2,7 +2,7 @@ module GovukTechDocs
   class PageReview
     attr_reader :page
 
-    def initialize(page, config={})
+    def initialize(page, config = {})
       @page = page
       @config = config
     end
@@ -35,7 +35,7 @@ module GovukTechDocs
       "https://#{owner_slack_workspace}.slack.com/messages/#{slack_identifier}"
     end
 
-    private
+  private
 
     def default_owner_slack
       @config[:tech_docs][:default_owner_slack]

--- a/lib/govuk_tech_docs/page_review.rb
+++ b/lib/govuk_tech_docs/page_review.rb
@@ -2,8 +2,9 @@ module GovukTechDocs
   class PageReview
     attr_reader :page
 
-    def initialize(page)
+    def initialize(page, config={})
       @page = page
+      @config = config
     end
 
     def review_by
@@ -24,13 +25,24 @@ module GovukTechDocs
     end
 
     def owner_slack
-      page.data.owner_slack
+      page.data.owner_slack || default_owner_slack
     end
 
     def owner_slack_url
+      return "" unless owner_slack_workspace
       # Slack URLs don't have the # (channels) or @ (usernames)
       slack_identifier = owner_slack.to_s.delete('#').delete('@')
-      "https://govuk.slack.com/messages/#{slack_identifier}"
+      "https://#{owner_slack_workspace}.slack.com/messages/#{slack_identifier}"
+    end
+
+    private
+
+    def default_owner_slack
+      @config[:tech_docs][:default_owner_slack]
+    end
+
+    def owner_slack_workspace
+      @config[:tech_docs][:owner_slack_workspace]
     end
   end
 end

--- a/lib/govuk_tech_docs/pages.rb
+++ b/lib/govuk_tech_docs/pages.rb
@@ -15,11 +15,12 @@ module GovukTechDocs
 
     def as_json
       pages.map do |page|
+        review = PageReview.new(page, @config)
         {
           title: page.data.title,
           url: "#{@config[:tech_docs][:host]}#{page.url}",
-          review_by: PageReview.new(page).review_by,
-          owner_slack: page.data.owner_slack,
+          review_by: review.review_by,
+          owner_slack: review.owner_slack,
         }
       end
     end

--- a/spec/govuk_tech_docs/page_review_spec.rb
+++ b/spec/govuk_tech_docs/page_review_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe GovukTechDocs::PageReview do
   describe '#under_review?' do
     it "is when there's a review_in date" do
       review_by = described_class.new(
-        double(data: double(review_in: "6 months"))
+        double(data: double(review_in: "6 months")),
+        {tech_docs: {owner_slack_workspace: "govuk"}}
       )
 
       expect(review_by.under_review?).to eql(true)
@@ -10,9 +11,19 @@ RSpec.describe GovukTechDocs::PageReview do
   end
 
   describe '#owner_slack_url' do
+    it "is blank when no workspace is configured" do
+      review_by = described_class.new(
+        double(data: double(owner_slack: "@foo")),
+        {tech_docs: {}}
+      )
+
+      expect(review_by.owner_slack_url).to be_empty
+    end
+
     it "links to Slack usernames" do
       review_by = described_class.new(
-        double(data: double(owner_slack: "@foo"))
+        double(data: double(owner_slack: "@foo")),
+        {tech_docs: {owner_slack_workspace: "govuk"}}
       )
 
       expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")
@@ -20,7 +31,8 @@ RSpec.describe GovukTechDocs::PageReview do
 
     it "links to Slack channels" do
       review_by = described_class.new(
-        double(data: double(owner_slack: "#foo"))
+        double(data: double(owner_slack: "#foo")),
+        {tech_docs: {owner_slack_workspace: "govuk"}}
       )
 
       expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")

--- a/spec/govuk_tech_docs/page_review_spec.rb
+++ b/spec/govuk_tech_docs/page_review_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GovukTechDocs::PageReview do
     it "is when there's a review_in date" do
       review_by = described_class.new(
         double(data: double(review_in: "6 months")),
-        {tech_docs: {owner_slack_workspace: "govuk"}}
+        tech_docs: { owner_slack_workspace: "govuk" }
       )
 
       expect(review_by.under_review?).to eql(true)
@@ -14,7 +14,7 @@ RSpec.describe GovukTechDocs::PageReview do
     it "is blank when no workspace is configured" do
       review_by = described_class.new(
         double(data: double(owner_slack: "@foo")),
-        {tech_docs: {}}
+        tech_docs: {}
       )
 
       expect(review_by.owner_slack_url).to be_empty
@@ -23,7 +23,7 @@ RSpec.describe GovukTechDocs::PageReview do
     it "links to Slack usernames" do
       review_by = described_class.new(
         double(data: double(owner_slack: "@foo")),
-        {tech_docs: {owner_slack_workspace: "govuk"}}
+        tech_docs: { owner_slack_workspace: "govuk" }
       )
 
       expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")
@@ -32,7 +32,7 @@ RSpec.describe GovukTechDocs::PageReview do
     it "links to Slack channels" do
       review_by = described_class.new(
         double(data: double(owner_slack: "#foo")),
-        {tech_docs: {owner_slack_workspace: "govuk"}}
+        tech_docs: { owner_slack_workspace: "govuk" }
       )
 
       expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")


### PR DESCRIPTION
* `default_owner_slack` means you can set a single owner which applies to all pages without a specific `owner_slack` item in the frontmatter.
* `owner_slack_workspace` allows customisation of the workspace to link to when an owner is present.