### PR TITLE
Fix bug with api_path config being mandatory and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.6.1
+
+### Make `api_path` configuration optional
+
+A bug in the previous release prevented the docs from being generated if
+`api_path` was missing. This is now fixed.
+
 ## 1.6.0
 
 Version 1.6.0 adds API reference generation, and improves the search function.

--- a/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
@@ -17,7 +17,8 @@ module GovukTechDocs
 
         # If no api path then just return.
         if @config['api_path'].to_s.empty?
-          raise 'No api path defined in tech-docs.yml'
+          @api_parser = false
+          return
         end
 
         # Is the api_path a url or path?

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.6.0".freeze
+  VERSION = "1.6.1".freeze
 end


### PR DESCRIPTION
1.6.0 included a bug that prevented the docs from generating if `api_path` was missing.

This is a fix that can be released as 1.6.1.