### PR TITLE
Render list of servers in API reference

### DIFF
--- a/example/source/pets.yml
+++ b/example/source/pets.yml
@@ -6,7 +6,10 @@ info:
   license:
     name: MIT
 servers:
-  - url: http://petstore.swagger.io/v1
+  - description: Production
+    url: http://petstore.swagger.io/v1
+  - description: Development
+    url: http://dev.petstore.swagger.io
 paths:
   /pets:
     get:

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "govuk-lint", "~> 3.7.0"
   spec.add_development_dependency "jasmine", "~> 3.1.0"
   spec.add_development_dependency "rspec", "~> 3.7.0"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
@@ -67,7 +67,7 @@ module GovukTechDocs
             text = text.strip
 
             if text == 'api&gt;'
-              @render.api_full(api_info, api_server)
+              @render.api_full(api_info, api_servers)
             elsif type == 'default'
               output = @render.path(text)
               # Render any schemas referenced in the above path
@@ -91,8 +91,8 @@ module GovukTechDocs
         @document.info
       end
 
-      def api_server
-        @document.servers[0]
+      def api_servers
+        @document.servers
       end
     end
   end

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -17,7 +17,7 @@ module GovukTechDocs
         @template_responses = get_renderer('responses.html.erb')
       end
 
-      def api_full(info, server)
+      def api_full(info, servers)
         paths = ''
         paths_data = @document.paths
         paths_data.each do |path_data|

--- a/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
@@ -1,9 +1,19 @@
 <h1 id="<%=  info.title.parameterize %>"><%= info.title %> v<%= info.version %></h1>
 <%= markdown(info.description) %>
-<% if server %>
-<h2 id="base-url">Base URL</h2>
-<p><strong><%= server.url %></strong></p>
+
+<% unless servers.empty? %>
+  <h2 id="servers">Servers</h2>
+  <div id="server-list">  
+    <% servers.each do |server| %>
+    <% if server.description %>
+    <p><strong><%= server.description %></strong></p>
+    <% end %>
+    <a href="<%= server.url %>"><%= server.url %></a>
+  <% end %>
+  </div>
 <% end %>
+
 <%= paths %>
+
 <h2 id="schemas">Schemas</h2>
 <%= schemas %>

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -1,0 +1,63 @@
+require 'json'
+require 'capybara/rspec'
+require 'govuk_tech_docs/api_reference/api_reference_renderer'
+
+
+RSpec.describe GovukTechDocs::ApiReference::Renderer do
+  describe '.api_full' do
+    before(:each) do
+      @spec = {
+        "openapi": "3.0.0",
+        "info": {
+          "title": "title",
+          "version": "0.0.1"
+        },
+        "paths": {}
+      }
+    end
+
+    it 'renders no servers' do
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(nil, document)
+      rendered = render.api_full(document.info, document.servers)
+
+      rendered = Capybara::Node::Simple.new(rendered)
+      expect(rendered).not_to have_css('h2#servers')
+      expect(rendered).not_to have_css('div#server-list')
+    end
+
+    it 'renders a server with no description' do
+      @spec['servers'] = [
+        { "url": "https://example.com" }
+      ]
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(nil, document)
+      rendered = render.api_full(document.info, document.servers)
+
+      rendered = Capybara::Node::Simple.new(rendered)
+      expect(rendered).to have_css('h2#servers')
+      expect(rendered).to have_css('div#server-list>a', text: 'https://example.com')
+      expect(rendered).not_to have_css('div#server-list>p')
+    end
+
+    it 'renders a list of servers' do
+      @spec['servers'] = [
+        { "url": "https://example.com", "description": "Production" },
+        { "url": "https://dev.example.com", "description": "Development" }
+      ]
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(nil, document)
+      rendered = render.api_full(document.info, document.servers)
+
+      rendered = Capybara::Node::Simple.new(rendered)
+      expect(rendered).to have_css('h2#servers')
+      expect(rendered).to have_css('div#server-list>a', text: 'https://example.com')
+      expect(rendered).to have_css('div#server-list>p>strong', text: 'Production')
+      expect(rendered).to have_css('div#server-list>a', text: 'https://dev.example.com')
+      expect(rendered).to have_css('div#server-list>p>strong', text: 'Development')
+    end
+  end
+end

--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -1,0 +1,59 @@
+require 'rack/file'
+require 'capybara/rspec'
+
+Capybara.app = Rack::File.new("example/build")
+
+RSpec.describe "OpenAPI reference" do
+  include Capybara::DSL
+
+  it "generates the api reference" do
+    when_the_site_is_created
+    when_i_view_an_api_reference_page
+    then_there_is_correct_api_info_content
+    then_there_is_correct_api_path_content
+    then_there_is_correct_api_schema_content
+
+    when_i_view_an_single_path_api_reference_page
+    then_there_is_correct_api_path_content
+  end
+
+  def when_the_site_is_created
+    puts `cd example && rm -rf build && bundle install && middleman build --verbose`
+  end
+
+  def when_i_view_an_api_reference_page
+    visit '/api-reference.html'
+  end
+
+  def when_i_view_an_single_path_api_reference_page
+    visit '/api-path.html'
+  end
+
+  def then_there_is_correct_api_info_content
+    # Title
+    expect(page).to have_css('h1', text: 'Swagger Petstore v1.0.0')
+    # Description
+    expect(page).to have_css('p', text: 'A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification')
+    # Servers
+    expect(page).to have_css('h2#servers', text: 'Servers')
+    expect(page).to have_css('a', text: 'http://petstore.swagger.io/v1')
+  end
+
+  def then_there_is_correct_api_path_content
+    # Path title
+    expect(page).to have_css('h2#pets', text: '/pets')
+    # Operation title
+    expect(page).to have_css('h3#pets-get', text: 'get')
+    # Path parameters
+    expect(page).to have_css('table', text: /\b(How many items to return at one time)\b/)
+    # Link to schema
+    expect(page).to have_css('table a[href="#schema-error"]')
+  end
+
+  def then_there_is_correct_api_schema_content
+    # Schema title
+    expect(page).to have_css('h3#schema-pet', text: 'Pet')
+    # Schema parameters
+    expect(page).to have_css('table', text: /\b(tag )\b/)
+  end
+end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -30,14 +30,6 @@ RSpec.describe "The tech docs template" do
 
     when_i_view_the_search_index
     then_there_is_indexed_content
-
-    when_i_view_an_api_reference_page
-    then_there_is_correct_api_info_content
-    then_there_is_correct_api_path_content
-    then_there_is_correct_api_schema_content
-
-    when_i_view_an_single_path_api_reference_page
-    then_there_is_correct_api_path_content
   end
 
   def when_the_site_is_created
@@ -113,42 +105,7 @@ RSpec.describe "The tech docs template" do
     visit '/search.json'
   end
 
-  def when_i_view_an_api_reference_page
-    visit '/api-reference.html'
-  end
-
   def then_there_is_indexed_content
     expect(page).to have_content 'troubleshoot'
-  end
-
-  def when_i_view_an_single_path_api_reference_page
-    visit '/api-path.html'
-  end
-
-  def then_there_is_correct_api_info_content
-    # Title
-    expect(page).to have_css('h1', text: 'Swagger Petstore v1.0.0')
-    # Description
-    expect(page).to have_css('p', text: 'A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification')
-    # Base URL
-    expect(page).to have_css('strong', text: 'http://petstore.swagger.io/v1')
-  end
-
-  def then_there_is_correct_api_path_content
-    # Path title
-    expect(page).to have_css('h2#pets', text: '/pets')
-    # Operation title
-    expect(page).to have_css('h3#pets-get', text: 'get')
-    # Path parameters
-    expect(page).to have_css('table', text: /\b(How many items to return at one time)\b/)
-    # Link to schema
-    expect(page).to have_css('table a[href="#schema-error"]')
-  end
-
-  def then_there_is_correct_api_schema_content
-    # Schema title
-    expect(page).to have_css('h3#schema-pet', text: 'Pet')
-    # Schema parameters
-    expect(page).to have_css('table', text: /\b(tag )\b/)
   end
 end


### PR DESCRIPTION
The API reference page now renders multiple servers and their descriptions. The section title of `Base URL` has been renamed to `Servers`. Added tests to check rendering of OpenAPI schemas that vary.

<img width="831" alt="image" src="https://user-images.githubusercontent.com/11051676/46533573-fbd08400-c89c-11e8-9c5a-af98478476d9.png">
