### PR TITLE
Fix hanging middleman

### DIFF
--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -29,7 +29,6 @@ module GovukTechDocs
   # @option options [Hash] livereload Options to pass to the `livereload`
   #   extension. Hash with symbols as keys.
   def self.configure(context, options = {})
-    context.activate :autoprefixer
     context.activate :sprockets
     context.activate :syntax
 
@@ -52,6 +51,7 @@ module GovukTechDocs
     end
 
     context.configure :build do
+      activate :autoprefixer
       activate :minify_css
       activate :minify_javascript
     end


### PR DESCRIPTION
There is currently an issue with middleman-autoprefixer which causes
middleman to hang: middleman/middleman-autoprefixer#33

When this happens, middleman no longer responds to requests and does not
refresh on source changes.

Moving the `activate :autoprefixer` command into the `context.configure :build` block seems to fix this and middleman behaves normally.