### PR TITLE
Depend on GDS's fork of middleman search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+The gem now uses `middleman-search-gds` rather than `middleman-search`, which
+removes the need for projects to point to the alphagov github repository in
+their Gemfiles. We will continue to maintain our own fork until the changes
+are merged into the upstream project.
+
 ## 1.6.2
 
 This version fixes an issue with Middleman hanging (PR #54). It also allows the API reference page to include multiple servers and their descriptions (PR #53).

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in govuk_tech_docs.gemspec
 gemspec
-
-gem 'middleman-search', :git => "git://github.com/alphagov/middleman-search.git"

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'govuk_tech_docs', path: '..'
-gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-livereload"
   spec.add_dependency "middleman-sprockets", "~> 4.0.0"
   spec.add_dependency "middleman-syntax", "~> 3.0.0"
-  spec.add_dependency "middleman-search"
+  spec.add_dependency "middleman-search-gds"
   spec.add_dependency "nokogiri"
   spec.add_dependency "redcarpet", "~> 3.3.2"
   spec.add_dependency "openapi3_parser"


### PR DESCRIPTION
We've been depending on this fork for a while, but projects have had
to include a line in their Gemfile to point to the github repo,
because it's not possible for a gem to depend on another gem that
hasn't been packaged.

Now that we've published our fork to rubygems, we can depend on it
directly.

See also: https://github.com/alphagov/middleman-search/pull/4