### PR TITLE
Prepare 1.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.6.3
+
 The gem now uses `middleman-search-gds` rather than `middleman-search`, which
 removes the need for projects to point to the alphagov github repository in
 their Gemfiles. We will continue to maintain our own fork until the changes

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.6.2".freeze
+  VERSION = "1.6.3".freeze
 end


### PR DESCRIPTION
This will release the change in https://github.com/alphagov/tech-docs-gem/pull/57

This should go out asap as changing the gem name in our fork has broken projects that are including it via github (eg see https://github.com/alphagov/tech-docs-template/pull/175) 
