### PR TITLE
Customise "Report issue" URL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,18 @@ show_contribution_banner: true
 github_repo: alphagov/example-repo
 ```
 
+## `source_urls`
+
+Customise the URLs that the contribution banner links to. Only useful if
+[show_contribution_banner](#show_contribution_banner) is turned on. By default, "Report issue" links
+to raising a GitHub issue but by modifying the `report_issue_url` it can link to an email address
+or another page.
+
+```yaml
+source_urls:
+  report_issue_url: mailto:support@example.com
+```
+
 ## `show_govuk_logo`
 
 Whether to show the GOV.UK crown logo.

--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -19,7 +19,13 @@ module GovukTechDocs
     end
 
     def report_issue_url
-      "#{repo_url}/issues/new?labels=bug&title=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+      url = config[:source_urls]&.[](:report_issue_url)
+
+      if url.nil?
+        "#{repo_url}/issues/new?labels=bug&title=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+      else
+        "#{url}?subject=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+      end
     end
 
     def repo_url

--- a/spec/govuk_tech_docs/source_urls_spec.rb
+++ b/spec/govuk_tech_docs/source_urls_spec.rb
@@ -1,0 +1,40 @@
+require 'ostruct'
+
+RSpec.describe GovukTechDocs::SourceUrls do
+  describe '#report_issue_url' do
+    it 'provides a GitHub issue link by default' do
+      current_page = generate_current_page('title', 'url')
+      config = generate_config('test/repo', 'https://test-docs/')
+      source_urls = GovukTechDocs::SourceUrls.new(current_page, config)
+
+      expect(source_urls.report_issue_url).to eql("https://github.com/test/repo/issues/new?labels=bug&title=Re: 'title'&body=Problem with 'title' (https://test-docs/url)")
+    end
+
+    it 'uses a custom URL when configured' do
+      current_page = generate_current_page('title', 'url')
+      config = generate_config('test/repo', 'https://test-docs/')
+      config[:source_urls] = {
+        report_issue_url: 'mailto:test@example.com'
+      }
+      source_urls = GovukTechDocs::SourceUrls.new(current_page, config)
+
+      expect(source_urls.report_issue_url).to eql("mailto:test@example.com?subject=Re: 'title'&body=Problem with 'title' (https://test-docs/url)")
+    end
+  end
+
+  def generate_config(repo, host)
+    {
+      tech_docs: {
+        host: host,
+        github_repo: repo,
+      }
+    }
+  end
+
+  def generate_current_page(title, url)
+    OpenStruct.new(
+      data: OpenStruct.new(title: title),
+      url: url,
+    )
+  end
+end


### PR DESCRIPTION
By default, clicking "Report issue" in the contribution banner at the
bottom of the page (if turned on) will link the user to creating an
issue in the docs' GitHub repo. Some end-users of the tech-docs gem may
instead want to link to a page containing a form or allow the user to send an email.

End-users can achieve this by adding

```yaml
source_urls:
  report_issue_url: https://some-other-site/support-form
```

to their `config/tech-docs.yml` file.

I've added tests for this behaviour in
`spec/govuk_tech_docs/source_urls_spec.rb`.