### PR TITLE
Fix sidebar highlighting for single page navigation

### DIFF
--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -70,7 +70,11 @@
     }
 
     function highlightActiveItemInToc(fragment) {
-      var $activeTocItem = $tocItems.filter('[href="' + window.location.pathname + fragment + '"]');
+      // Navigation items for single page navigation don't necessarily include the path name, but
+      // navigation items for multipage navigation items do include it. This checks for either case.
+      var $activeTocItem = $tocItems.filter(
+        '[href="' + window.location.pathname + fragment + '"],[href="' + fragment + '"]'
+      );
       // Navigation items with children don't contain fragments in their url
       // Check to see if any nav items contain just the path name.
       if(!$activeTocItem.get(0)) {


### PR DESCRIPTION
Items in the left navigation bar were no longer being highlighted when
active for single page sites (this still worked for multipage sites.)
This is because the `href` attribute for the table of content items has
a different format for single page sites and multipage sites. We were
only looking at the format for multipage table of content items when
deciding which item to highlight, so this commit now ensures we look at
both formats.