### PR TITLE
Don't be picky about bundler versions

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
 
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "capybara", "~> 2.18.0"
   spec.add_development_dependency "govuk-lint", "~> 3.7.0"


### PR DESCRIPTION
By requiring bundler 1 we confuse Travis because by default, rvm now installs Bundler version 2. This causes all PRs to fail on CI (https://github.com/alphagov/tech-docs-gem/pull/64 https://github.com/alphagov/tech-docs-gem/pull/63).