### PR TITLE
Less stringent filtering for populating pages.json

### DIFF
--- a/lib/govuk_tech_docs/pages.rb
+++ b/lib/govuk_tech_docs/pages.rb
@@ -26,7 +26,7 @@ module GovukTechDocs
     end
 
     def pages
-      sitemap.resources.select { |page| page.url.end_with?('.html') && page.data.title }
+      sitemap.resources.select { |page| page.data.title }
     end
   end
 end


### PR DESCRIPTION
Not all page URLs will end in `.html`, especially if people are using
directories and `index.html` files to organise their docs. This change
should make sure all pages are included provided they have a title
defined in their frontmatter.