### PR TITLE
Automate releases to Rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ script:
 before_install:
   - rvm @global do gem uninstall bundler -a -x
   - rvm @global do gem install bundler -v 1.17.3
+deploy:
+  provider: rubygems
+  gem: govuk_tech_docs
+  api_key:
+    secure: CY9C+IUqUeYWqXSyQgfF5swdYw1rRtYi0ai1xasD3R5rwARF6Qr8CnmdSBjfT2S84fXQiMza45Jto4w1jiy3o4wpxuKN68xEB7J4W/YEpFcZectzsmXwcMJH+DXh720KFIX2xiHaG5N0nWzAoV+6zgw6Vq24IXYE33wO6BgCmTe3vtO+Apg0+wDRAOuJ4T5XfSyWUvG8JqLRb81t+WbrsOLcUgZn24DHvs+lrjXTDDTzrgwTuKeaKd+h+mfxlHZD+Xxbcy624qop5ICwOOP0koRXCdVmTOSZ4mNI10+loCyA1B5Tryj/2wweyc8CanqRMniF8p/BxLV1sAwihpCmCpuWUyxq2pTPSgjF1A1f5hXwkAT/HiaXLzXKyO1REnbtLHYvre10EIYIII4nDAtCZP0YLYvPoKQUrAydeWiQ4jL+cyEeN/8Dznx2OPrhcwxazsElMm0yOZDNXERNIf3IVnQshxMFxQfGW3NTG8XR4l5PHAI2XqKy/O/VGbiRcNV3EYVG5w/KumB698BGDGV2QPOlh3JOEkebXTGDsMJj/gzZik2BtvAqYatwgx7oiYzvhEPz0m9o/DTS7Gf/5Hkj3iV2mpcNtRMc0HKmS7bwkv8Cl6dWECt7PWQ8Kz5ttrCKRmTCJDgra2xLFuV8kbBISPkKKv87KCXzxthM8ps94WE=
+  on:
+    repo: alphagov/tech-docs-gem
+    branch: master

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ Or, on the command line, run `bundle exec rake jasmine:ci`.
 
 ## Releasing new versions
 
-At the moment this gem has to be released manually. There's a [story on the Reliability Engineering backlog](https://trello.com/c/gRQ8OnBl) to automate this.
-
 To release a new version, create a new Pull Request that updates [version.rb](lib/govuk_tech_docs/version.rb) and [CHANGELOG.md](CHANGELOG.md). Don't mix this in with other changes - this makes it easier to find out what was released when. See [this PR to release a new version as an example](https://github.com/alphagov/tech-docs-gem/pull/15).
 
-[Owners of the Rubygem](https://rubygems.org/gems/govuk_tech_docs#gem__owners) can then run `rake release` to release a new version.
+Travis will automatically release a [new version to Rubygems.org](https://rubygems.org/gems/govuk_tech_docs).
 
 ## License
 


### PR DESCRIPTION
This sets up a deployment on Travis, which hopefully means it'll release a new version every time we merge a new version to master. This prevents the project from being dependent on me to release new versions.

We've encrypted the Rubygems API key. The API key belongs to the https://rubygems.org/profiles/govuk user. Note that this user belongs to the GOV.UK programme, which has no formal relationship to the tech docs template. However until there's a team officially owning the project, we'll have to do it like this.

Thanks to @36degrees for helping me understand Travis.