### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.7.0
+
+New features: this release adds support for a full-width page (#63) and adding HTML to the `head` of the page (#64).
+
+This release also makes sure that all pages are returned in the `/api/pages.json` endpoint (#66).
 
 ## 1.6.3
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.6.3".freeze
+  VERSION = "1.7.0".freeze
 end


### PR DESCRIPTION
This is also a test of the automatic release process (https://github.com/alphagov/tech-docs-gem/pull/67). Once merged version 1.7.0 should appear on Rubygems in 10 minutes or so. 