### PR TITLE
Make specific folder to be excempt from minification

### DIFF
--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -52,8 +52,8 @@ module GovukTechDocs
 
     context.configure :build do
       activate :autoprefixer
-      activate :minify_css
-      activate :minify_javascript
+      activate :minify_css, ignore: ['/raw_assets/*']
+      activate :minify_javascript, ignore: ['/raw_assets/*']
     end
 
     context.config[:tech_docs] = YAML.load_file('config/tech-docs.yml').with_indifferent_access


### PR DESCRIPTION
This makes it possible to serve and build CSS and JS files in their raw, unminified and unmodified form.
Every CSS and JS file in the `raw_assets` folder will be ignored by the minifiers.

My use case:
I need to add downloadable and installable [userscripts](https://en.wikipedia.org/wiki/Userscript) and [userstyles](https://en.wikipedia.org/wiki/Stylish) to my project (alphagov/accessibility-personas). But the minification strips the comments which are essential for them to work.

I have not documented this yet because it doesn't really fit anywhere. (It's neither a configuration option, nor a frontmatter setting, nor has it anything to do with page expiry.) Shall I just create a new Markdown file?