### PR TITLE
Use 'url_for' in header to make automatic link types possible

### DIFF
--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -2,7 +2,7 @@
   <div class="header__container">
     <div class="header__brand">
       <% if config[:tech_docs][:service_link] %>
-        <a href="<%= config[:tech_docs][:service_link] %>">
+        <a href="<%= url_for config[:tech_docs][:service_link] %>">
       <% else %>
         <span>
       <% end %>
@@ -33,7 +33,7 @@
           <ul>
             <% config[:tech_docs][:header_links].each do |title, path| %>
               <li<% if active_page(path) %> class="active"<% end %>>
-                <a href="<%= path %>"><%= title %></a>
+                <a href="<%= url_for path %>"><%= title %></a>
               </li>
             <% end %>
           </ul>


### PR DESCRIPTION
It is a best practice to use `url_for` (or `link_to`) for URLs so that links are automatically converted to either relative or absolute, depending on setting.
This will make it work in setups which are in a subdirectory, like GitHub Pages.