### PR TITLE
Add github_branch config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.1
+
+### Make `github_branch` configurable
+
+Previously it was hard-coded to master unless you set the source_url on every page
+
 ## 1.7.0
 
 New features: this release adds support for a full-width page (#63) and adding HTML to the `head` of the page (#64).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.7.1
+## Unreleased
 
 ### Make `github_branch` configurable
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,14 @@ Your repository. Required if [show_contribution_banner](#show-contribution-banne
 github_repo: alphagov/example-repo
 ```
 
+## `github_branch`
+
+Your github branch name. Useful if your default branch is not named master.
+
+```yaml
+github_branch: source
+```
+
 ## `google_site_verification`
 
 Adds a [Google Site Verification code](https://support.google.com/webmasters/answer/35179?hl=en) to the meta tags.

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -38,6 +38,7 @@ enable_search: true
 show_contribution_banner: true
 
 github_repo: alphagov/example-repo
+github_branch: source
 
 redirects:
   /something/old.html: /index.html

--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -26,6 +26,10 @@ module GovukTechDocs
       "https://github.com/#{config[:tech_docs][:github_repo]}"
     end
 
+    def repo_branch
+      config[:tech_docs][:github_branch] || 'master'
+    end
+
   private
 
     # If a `page` local exists, see if it has a `source_url`. This is used by the
@@ -42,7 +46,7 @@ module GovukTechDocs
 
     # As the last fallback link to the source file in this repository.
     def source_from_file
-      "#{repo_url}/blob/master/source/#{current_page.file_descriptor[:relative_path]}"
+      "#{repo_url}/blob/#{repo_branch}/source/#{current_page.file_descriptor[:relative_path]}"
     end
 
     def locals

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "The tech docs template" do
 
   def then_there_is_a_source_footer
     %w[
-      https://github.com/alphagov/example-repo/blob/master/source/index.html.md.erb
+      https://github.com/alphagov/example-repo/blob/source/source/index.html.md.erb
       https://github.com/alphagov/example-repo
     ].each do |url|
       expect(page).to have_link(nil, href: url)


### PR DESCRIPTION
We're publishing to github pages from an organisation site (hmcts.github.io)
Organisation sites require that your master branch publishes the assets

So we've created another branch `source` which has our source files

I would rather not set `source_url` on every page, it'll end up being wrong in some places

Would you be happy to take this configuration option?