### PR TITLE
Allow `full_service_name` to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+New feature: add `full_service_name` config option, used in the browser title and meta tags (#71).
+
 ## 1.7.0
 
 New features: this release adds support for a full-width page (#63) and adding HTML to the `head` of the page (#64).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,16 @@ Example:
 service_name: "Platform as a Service"
 ```
 
+## `full_service_name`
+
+The full service name (maybe with GOV.UK)
+
+Example:
+
+```yaml
+full_service_name: "GOV.UK Pay"
+```
+
 ## `service_link`
 
 What the service name in the header links to.

--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -41,7 +41,7 @@ module GovukTechDocs
     end
 
     def site_name
-      config[:tech_docs][:service_name]
+      config[:tech_docs][:full_service_name] || config[:tech_docs][:service_name]
     end
 
     def page_description

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe GovukTechDocs::MetaTags do
     it 'returns all the extra meta tags' do
       config = generate_config(
         host: "https://www.example.org",
-        service_name: "Test Site",
+        service_name: "Foo",
+        full_service_name: "Test Site",
       )
 
       current_page = double("current_page",


### PR DESCRIPTION
In the GOV.UK developer docs our `service_name` is "Developer docs" to avoid duplicating the "GOV.UK" in the header. In meta tags and browser title we want to use the full service name "GOV.UK Developer docs". This makes that a config option.