### PR TITLE
Update to the current version of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,4 @@
 language: ruby
-rvm:
-  - 2.4.2
-script:
-  - bundle exec rake
-before_install:
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.17.3
 deploy:
   provider: rubygems
   gem: govuk_tech_docs

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
 
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "capybara", "~> 2.18.0"
   spec.add_development_dependency "govuk-lint", "~> 3.7.0"


### PR DESCRIPTION
There were clashes on Travis between the version of bundler required by middleman
and the version being installed by the `gemspec`.