### PR TITLE
Fix multipage site build with custom http_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+This release fixes a bug (#79 - reported in
+[alphagov/tech-docs-template#183][tdt-183]) which prevented a multipage site
+from being generated when a custom `http_prefix` was configured.
+
+[tdt-183]: https://github.com/alphagov/tech-docs-template/issues/183
+
 ## 1.8.0
 
 🎉 Our first contributor from outside of GDS. Thanks [@timja](https://github.com/timja) from [HMCTS](https://hmcts.github.io)! 🤝

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -45,11 +45,21 @@ module GovukTechDocs
           # Avoid redirect pages
           next if content.include? "http-equiv=refresh"
           # If this page has children, just print the title and recursively
-          # render the children.
-          # If not, print the heading structure.
+          # render the children. If not, print the heading structure.
+
           # We avoid printing the children of the root index.html as it is the
-          # parent of every other top level file.
-          if resource.children.any? && resource.url != "/"
+          # parent of every other top level file.  We need to take any custom
+          # prefix in to consideration when checking for the root index.html.
+          # The prefix may be set with or without a trailing slash: make sure
+          # it has one for this comparison check.
+          home_url =
+            if config[:http_prefix].end_with?("/")
+              config[:http_prefix]
+            else
+              config[:http_prefix] + "/"
+            end
+
+          if resource.children.any? && resource.url != home_url
             output += %{<ul><li><a href="#{resource.url}">#{resource.data.title}</a>\n}
             output += render_page_tree(resource.children, current_page, config, current_page_html)
             output += '</li></ul>'

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -140,6 +140,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
 
       config = {
+        http_prefix: "/",
         tech_docs: {
           max_toc_heading_level: 3
         }
@@ -173,6 +174,55 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
     end
 
+    it 'builds a table of contents from several page resources with a custom http prefix ocnfigured' do
+      resources = []
+      resources[0] = FakeResource.new('/prefix/index.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, 'Index');
+      resources[1] = FakeResource.new('/prefix/a.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, 'Sub page A', resources[0]);
+      resources[2] = FakeResource.new('/prefix/b.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, 'Sub page B', resources[0]);
+      resources[0].add_children [resources[1], resources[2]]
+
+      current_page = double("current_page",
+        data: double("page_frontmatter", description: "The description.", title: "The Title"),
+        url: "/prefix/index.html",
+        metadata: { locals: {} })
+
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
+
+      config = {
+        http_prefix: "/prefix",
+        tech_docs: {
+          max_toc_heading_level: 3
+        }
+      }
+
+      expected_multi_page_table_of_contents = %{
+<ul><li><a href="/prefix/index.html">Index</a>
+<ul>
+  <li>
+    <a href="/prefix/a.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/prefix/a.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>
+    <a href="/prefix/b.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/prefix/b.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+</li></ul>
+      }
+
+      expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
+    end
+
     it 'builds a table of contents from a single page resources' do
       resources = []
       resources.push FakeResource.new('/index.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>');
@@ -185,6 +235,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
 
       config = {
+        http_prefix: "/",
         tech_docs: {
           max_toc_heading_level: 3,
           multipage_nav: true


### PR DESCRIPTION
We need to take any custom prefix set in `config.http_prefix` in to consideration when generating multipage tables of content. Previously we were assuming that the root page was at `/`, which is not the case with the custom prefix set.

Fixes alphagov/tech-docs-template#183.