### PR TITLE
fix: generate multipage TOC with http_prefix

### DIFF
--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -19,10 +19,18 @@ module GovukTechDocs
       end
 
       def multi_page_table_of_contents(resources, current_page, config, current_page_html = nil)
+        # Determine
+        home_url =
+          if config[:http_prefix].end_with?("/")
+            config[:http_prefix]
+          else
+            config[:http_prefix] + "/"
+          end
+
         # Only parse top level html files
         # Sorted by weight frontmatter
         resources = resources
-        .select { |r| r.path.end_with?(".html") && (r.parent.nil? || r.parent.url == "/") }
+        .select { |r| r.path.end_with?(".html") && (r.parent.nil? || r.parent.url == home_url) }
         .sort_by { |r| [r.data.weight ? 0 : 1, r.data.weight || 0] }
 
         render_page_tree(resources, current_page, config, current_page_html)

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -153,7 +153,102 @@ describe GovukTechDocs::TableOfContents::Helpers do
                             path: "/1/2/3/index.html",
                             metadata: { locals: {} })
 
-      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>'
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
+
+      config = {
+        http_prefix: "/",
+        tech_docs: {
+          max_toc_heading_level: 3
+        }
+      }
+
+      expected_multi_page_table_of_contents = %{
+<ul><li><a href="/index.html">Index</a>
+<ul>
+  <li>
+    <a href="/a.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/a.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>
+    <a href="/b.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/b.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+</li></ul>
+      }
+
+      expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
+    end
+
+    it 'builds a table of contents from several page resources with a custom http prefix configured' do
+      resources = []
+      resources[0] = FakeResource.new('/prefix/index.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, 'Index');
+      resources[1] = FakeResource.new('/prefix/a.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, 'Sub page A', resources[0]);
+      resources[2] = FakeResource.new('/prefix/b.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, 'Sub page B', resources[0]);
+      resources[0].add_children [resources[1], resources[2]]
+
+      current_page = double("current_page",
+        data: double("page_frontmatter", description: "The description.", title: "The Title"),
+        url: "/prefix/index.html",
+        metadata: { locals: {} })
+
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
+
+      config = {
+        http_prefix: "/prefix",
+        tech_docs: {
+          max_toc_heading_level: 3
+        }
+      }
+
+      expected_multi_page_table_of_contents = %{
+<ul><li><a href="/prefix/index.html">Index</a>
+<ul>
+  <li>
+    <a href="/prefix/a.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/prefix/a.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>
+    <a href="/prefix/b.html#heading-one">Heading one</a>
+    <ul>
+      <li>
+        <a href="/prefix/b.html#heading-two">Heading two</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+</li></ul>
+      }
+
+      expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
+    end
+
+    it 'builds a table of contents from a single page resources' do
+      resources = []
+      resources.push FakeResource.new('/index.html', '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>');
+
+      current_page = double("current_page",
+        data: double("page_frontmatter", description: "The description.", title: "The Title"),
+        url: "/index.html",
+        metadata: { locals: {} })
+
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
 
       config = {
         http_prefix: "/",


### PR DESCRIPTION
Please see replication steps here: https://github.com/alphagov/tech-docs-template/issues/183#issuecomment-478942982

Whilst the test already in place appears to work, I'm not sure it is covering my particular case because when I build my site it is not generating files within a prefixed folder, so I may need a bit of guidance to write additional test (or correct my approach!) ...

For example, when `http_prefix=/prefix/`, given my `source/`:

```
|- source/
|--documentation/
|--index.html.md.erb
|--page2.html.md.erb
```

This is generating files in the build directory as so:

```
|- build/
|--index.html
|--page2.html
```

But the test in place appears to expect generated assets to be:

```
|- build/
|--prefix/index.html
|--prefix/page2.html
```

The attached PR does fix the issue for me, however.