### PR TITLE
Keep search results when opening in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ removes the need for projects to point to the alphagov github repository in
 their Gemfiles. We will continue to maintain our own fork until the changes
 are merged into the upstream project.
 
+## Unreleased
+
+Fixes bug where search results disappear when opening results in a new tab, making it difficult to open several results in a batch (PR #86).
+
 ## 1.6.2
 
 This version fixes an issue with Middleman hanging (PR #54). It also allows the API reference page to include multiple servers and their descriptions (PR #53).

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -94,7 +94,7 @@
       }
 
       // When selecting navigation link, close the search results.
-      $('.toc').on('click','a', function(e) {
+      $('#toc').on('click','a', function(e) {
         hideResults();
       })
     }


### PR DESCRIPTION
| Before | After |
|-------|-------|
|![new tab behaviour hides search result](https://user-images.githubusercontent.com/5111927/59210137-c2c37e80-8ba4-11e9-911a-d9dccd500634.gif)|![new tab behaviour keeps search results in place](https://user-images.githubusercontent.com/5111927/59210159-d1aa3100-8ba4-11e9-8b98-0b8e75f63d34.gif)|

Fixes an issue whereby if you 'CMD + Click' on search results, the search results are closed.

(This made it difficult to line up several useful looking results in new tabs; you'd either have to click
on the search input again and re-trigger the search to re-show the results and
enable opening a result in a new tab, or give up on tabs altogether and navigate
in your current window).
    
The selector '.toc' contains the search input, the sidebar and the search results
themselves. So calling 'hideResults' when '.toc a' is clicked meant that the
search results were hidden the moment you click on a search result.
    
The selector '#toc' contains only the search input and sidebar - NOT the search
results, so we can safely call 'hideResults' when '#toc a' is clicked. This means
we can right-click on search results and open them in new tabs, without the results
being cleared. It also means we haven't broken the existing behaviour (which is that
if a navigation link in the sidebar is clicked, the search results should be hidden - as
the search results are overlayed on top).