### PR TITLE
Bump to 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.3
+
+Fixes bug where search results disappear when opening results in a new tab, making it difficult to open several results in a batch (PR #86).
+
 ## 1.8.2
 
 Adds a `show_expiry` config option to allow you to choose whether to show the review due date and expired banner from your pages. Find out more about the [page expiry and review feature][expiry].
@@ -34,10 +38,6 @@ The gem now uses `middleman-search-gds` rather than `middleman-search`, which
 removes the need for projects to point to the alphagov github repository in
 their Gemfiles. We will continue to maintain our own fork until the changes
 are merged into the upstream project.
-
-## Unreleased
-
-Fixes bug where search results disappear when opening results in a new tab, making it difficult to open several results in a batch (PR #86).
 
 ## 1.6.2
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "1.8.2".freeze
+  VERSION = "1.8.3".freeze
 end


### PR DESCRIPTION
Includes https://github.com/alphagov/tech-docs-gem/pull/86

I mistakenly put `Unreleased` in the wrong part of the CHANGELOG 😳 have fixed that here.