### PR TITLE
Fail tests if the middleman site doesn't build properly

### DIFF
--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "OpenAPI reference" do
   end
 
   def when_the_site_is_created
-    puts `cd example && rm -rf build && bundle install && middleman build --verbose`
+    rebuild_site!
   end
 
   def when_i_view_an_api_reference_page

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "The tech docs template" do
   end
 
   def when_the_site_is_created
-    puts `cd example && rm -rf build && bundle install && middleman build --verbose`
+    rebuild_site!
   end
 
   def and_i_visit_the_homepage

--- a/spec/features/page_expiration_spec.rb
+++ b/spec/features/page_expiration_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe "Page expiration" do
   end
 
   def when_the_site_is_created
-    `cd example && rm -rf build && bundle install --quiet && middleman build`
+    rebuild_site!
   end
 
   def when_the_site_is_created_hiding_expiry
-    `cd example && rm -rf build && bundle install --quiet && CONFIG_FILE=config/hide-expiry.yml middleman build`
+    rebuild_site!(config: "config/hide-expiry.yml")
   end
 
   def and_i_visit_an_expired_page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,19 @@ require 'govuk_tech_docs'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  def rebuild_site!(config: "config/tech-docs.yml")
+    command = [
+      "cd example",
+      "rm -rf build",
+      "bundle install --quiet",
+      "CONFIG_FILE=#{config} NO_CONTRACTS=true middleman build --bail --show-exceptions"
+    ].join(" && ")
+
+    unless system(command)
+      raise "`middleman build` failed, see the log for more info"
+    end
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
As we're currently seeing in https://github.com/alphagov/tech-docs-gem/pull/89, when middleman encounters errors during the build of the example site, the tests will still pass as long as the HTML is correctly generated.

With this commit, we change that behaviour to fail whenever `middleman build` encounters a problem. This will prevent us from merging in code that will prevent the CSS and JS from being built, as is happening in the aforementioned PR.

As a bonus, I've DRY-ed up the testing code, improved the test output, and sped up the tests by using NO_CONTRACTS (see https://github.com/alphagov/govuk-developer-docs/pull/1532 for more info).