### PR TITLE
Use focus styles from GOV.UK Frontend

### DIFF
--- a/lib/assets/stylesheets/_accessibility.scss
+++ b/lib/assets/stylesheets/_accessibility.scss
@@ -4,6 +4,5 @@ a {
 }
 
 a:focus {
-  background-color: $focus-colour;
-  outline: 3px solid $focus-colour;
+  @include govuk-focused-text;
 }

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -1,6 +1,3 @@
-@import "core";
-@import "vendor/fixedsticky";
-
 $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 
@@ -8,3 +5,6 @@ $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 
 @import "../../../node_modules/govuk-frontend/govuk/all";
+
+@import "core";
+@import "vendor/fixedsticky";

--- a/lib/assets/stylesheets/govuk_frontend_toolkit/colours/_palette.scss
+++ b/lib/assets/stylesheets/govuk_frontend_toolkit/colours/_palette.scss
@@ -60,7 +60,7 @@ $link-active-colour: $light-blue;
 $link-hover-colour: $light-blue;
 $link-visited-colour: #4c2c92;
 $button-colour: #00823b;
-$focus-colour: $yellow;
+// $focus-colour: $yellow; DEPRECATED BY $govuk-focus-colour
 $text-colour: $black;             // Standard text colour
 $secondary-text-colour: $grey-1;  // Section headers, help text etc.
 $border-colour: $grey-2;          // Borders, seperators, rules, keylines etc.

--- a/lib/assets/stylesheets/modules/_collapsible.scss
+++ b/lib/assets/stylesheets/modules/_collapsible.scss
@@ -28,7 +28,7 @@
   color: inherit;
   padding: 0;
   &:focus {
-    outline: 3px solid $focus-colour;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 }
 .collapsible__toggle-icon {

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -24,7 +24,7 @@
       appearance: none;
 
       &:focus {
-        outline: 3px solid $focus-colour;
+        outline: $govuk-focus-width solid $govuk-focus-colour;
         outline-offset: 0;
       }
     }
@@ -102,7 +102,7 @@ html.has-search-results-open {
   border: 0;
   padding: 0;
   &:focus {
-    outline: 3px solid $focus-colour;;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
     outline-offset: 0;
   }
   &::after {


### PR DESCRIPTION
This updates the CSS to use the focus styles from GOV.UK Frontend.

I've used https://design-system.service.gov.uk/get-started/focus-states as a guide.

I've disabled the `$focus-colour` variable in our vendored frontend toolkit to make sure we aren't using it anymore.

Re: https://github.com/alphagov/tech-docs-gem/issues/93