### PR TITLE
Simplify how JavaScript is initialised and slightly improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #95: Simplify how JavaScript is initialised and slightly improve performance](https://github.com/alphagov/tech-docs-gem/pull/95)
+
 ## 2.0.10
+
+### Fixes
 
 - [Pull request #160: Make sure IDs on collapsible navigation are unique](https://github.com/alphagov/tech-docs-gem/pull/160)
 

--- a/lib/assets/javascripts/_start-modules.js
+++ b/lib/assets/javascripts/_start-modules.js
@@ -7,6 +7,4 @@
 //= require _modules/search
 //= require _modules/collapsible-navigation
 
-$(document).ready(function () {
-  GOVUK.modules.start()
-})
+GOVUK.modules.start()

--- a/lib/assets/javascripts/govuk_tech_docs.js
+++ b/lib/assets/javascripts/govuk_tech_docs.js
@@ -6,7 +6,5 @@
 //= require _start-modules
 //= require govuk/all.js
 
-$(function () {
-  $('.fixedsticky').fixedsticky()
-  GOVUKFrontend.initAll()
-})
+window.GOVUKFrontend.initAll()
+$('.fixedsticky').fixedsticky()


### PR DESCRIPTION
This is part of a bigger piece of work to remove the dependency on jQuery.

There is no need to rely on jQuery's document.ready() method.
By placing application.js at the bottom of the page, the script will be
executed after all preceding DOM is loaded anyway.

There is also a slight performance improvement (HTML parsing and loading
of CSS and images isn't blocked by the scripts)