### PR TITLE
Ensure GOV.UK frontend is installed via gemspec

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -3,6 +3,13 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "govuk_tech_docs/version"
 
+`npm install`
+abort 'npm install failed' unless $?.success?
+
+unless File.exist?('node_modules/govuk-frontend/govuk/all.scss')
+  abort 'govuk-frontend npm package not installed'
+end
+
 Gem::Specification.new do |spec|
   spec.name          = "govuk_tech_docs"
   spec.version       = GovukTechDocs::VERSION


### PR DESCRIPTION
Commit message
---

```
The .travis.yml does this but putting it in the gemspec means it happens
locally as well when running 'rake build'

If this gem, when built does not include govuk-frontend, then it
functionally does not work. Add a check in the gemspec that a file from
govuk-frontend exists, so that building the gem will fail if 'npm
install' has not been run, or if govuk-frontend has been removed.

...
```

What
---

See commit message

How to review
---

```
cd /tmp

mkdir test-govuk-tech-docs

cat <<EOF > Gemfile
source 'https://rubygems.org'

gem 'govuk_tech_docs', '= 2.0.0.pre.test.pre.release.pre.525'
EOF

rbenv shell 2.6.3

gem install bundler:2.0.1

bundle install --path vendor

find vendor/ruby/2.6.0/gems/govuk_tech_docs-2.0.0.pre.test.pre.release.pre.525 -name govuk-frontend -type d
```

Who can review
---

Done as pair with Jon Heslop, no review required