### PR TITLE
Bundle remaining assets type from GOV.UK Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+This fixes ensures all assets from govuk-frontend are bundled; we were missing some PNG, SVG and ICO files.
+
 ## 2.0.1
 
 This fixes an issue where Travis CI wasn’t packaging up the gem with the govuk-frontend module.

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   files_in_git = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   # Include assets from GOV.UK Frontend library in the distributed gem
-  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,woff,woff2}"]
+  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,woff,woff2,png,svg,ico}"]
 
   spec.files         = files_in_git + govuk_frontend_assets
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "2.0.1".freeze
+  VERSION = "2.0.2".freeze
 end


### PR DESCRIPTION
The Crown logo appears to be missing after upgrading to 2.0.1. Since this bug happens in the gem-cutting process (on Travis) I can't guarantee the fix but am pretty sure it should check out.