### PR TITLE
Fix the border mismatch in code blocks

### DIFF
--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -80,6 +80,7 @@
 
   table {
     @include govuk-responsive-margin(6, "bottom");
+    table-layout: fixed;
   }
 
   pre + h2 {
@@ -119,11 +120,6 @@
     overflow: auto;
     position: relative;
     border: 1px solid $code-02;
-    // Restrict the width of pre tags, as they have a tendency grow larger than
-    // the viewport when placed within table cells.
-    // @todo: Use table-layout: fixed, and remove the max-width definition from
-    // .technical-documentation so tables can fill the viewport.
-    max-width: 40em;
   }
 
   pre code {


### PR DESCRIPTION
Fixes #100 -- the border now lines up with the bounds of the code block
and placing code blocks in table cells does not allow the table to grow
wider than the viewport. Overflowing text will be hidden in this case.

![Screen Shot 2019-09-05 at 16 25 40](https://user-images.githubusercontent.com/2650888/64355944-fa9e5e80-cff9-11e9-8ae1-626b2e45562a.png)
