### PR TITLE
Fix bug in API docs that shows required attributes as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+Fix bug in API docs that shows required attributes as optional  (#113)
+
 ## 2.0.3
 
 Fixes a couple of styling issues: [#100](https://github.com/alphagov/tech-docs-gem/issues/100) and [#106](https://github.com/alphagov/tech-docs-gem/issues/106).

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -1,7 +1,7 @@
 <h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
 <%= markdown(schema.description) %>
 <% if properties.any? %>
-<table>
+<table class='<%= id.parameterize %>'>
 <thead>
 <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
 </thead>
@@ -10,7 +10,7 @@
 <tr>
 <td><%= property_name %></td>
 <td><%= property_attributes.type %></td>
-<td><%= property_attributes.required.present? %></td>
+<td><%= property_name.in?(schema.required.to_a) %></td>
 <td><%= markdown(property_attributes.description) %></td>
 <td>
   <%=

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -6,21 +6,21 @@
 <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
 </thead>
 <tbody>
-<% properties.each do |property| %>
+<% properties.each do |property_name, property_attributes| %>
 <tr>
-<td><%= property[0] %></td>
-<td><%= property[1].type %></td>
-<td><%= property[1].required.present? %></td>
-<td><%= markdown(property[1].description) %></td>
+<td><%= property_name %></td>
+<td><%= property_attributes.type %></td>
+<td><%= property_attributes.required.present? %></td>
+<td><%= markdown(property_attributes.description) %></td>
 <td>
   <%=
-  schema = property[1]
+  linked_schema = property_attributes
   # If property is an array, check the items property for a reference.
-  if property[1].type == 'array'
-    schema = property[1]['items']
+  if property_attributes.type == 'array'
+    linked_schema = property_attributes['items']
   end
   # Only print a link if it's a referenced object.
-  get_schema_link(schema) if schema.node_context.referenced_by.to_s.include? '#/components/schemas' and !schema.node_context.source_location.to_s.include? '/properties/' %>
+  get_schema_link(linked_schema) if linked_schema.node_context.referenced_by.to_s.include?('#/components/schemas') && !linked_schema.node_context.source_location.to_s.include?('/properties/') %>
 </td>
 </tr>
 <% end %>

--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -53,7 +53,11 @@ RSpec.describe "OpenAPI reference" do
   def then_there_is_correct_api_schema_content
     # Schema title
     expect(page).to have_css('h3#schema-pet', text: 'Pet')
+
     # Schema parameters
     expect(page).to have_css('table', text: /\b(tag )\b/)
+
+    # Check that the "required" column is true for the `id` attribute
+    expect(page).to have_css('table.schema-pet td:nth(3)', text: "true")
   end
 end


### PR DESCRIPTION
:wave: from [DfE](https://github.com/DFE-Digital)!

This fixes a bug in the [OpenAPI reference renderer](https://tdt-documentation.london.cloudapps.digital/add_an_openapi_specification.html) that affects which attributes of a [schema](https://swagger.io/docs/specification/data-models/) are considered to be required.

For the uninitiated: in OpenAPI, schemas allow you to define what objects/resources/models your API will return. It uses [JSON Schema](https://json-schema.org/) for this.

For example:

```yml
schemas:
  Pet:
    required:
      - id
      - name
    properties:
      id:
        type: integer
        format: int64
      name:
        type: string
      tag:
        type: string
```

This means that any `Pet` objects will have at least an `id` and a `name`, and an optional `tag`.

Currently the logic to display which attributes are required is wrong, because the code expects something like:

```yml
id:
  type: integer
  format: int64
  required: true
```

This isn't valid JSON Schema as far as I can see: 

https://json-schema.org/understanding-json-schema/reference/object.html#required-properties

This commit fixes the bug by making the check look at the `required` array in the schema, rather than the property.

## How to review

[Read the main commit](https://github.com/alphagov/tech-docs-gem/pull/113/commits/5f2fd1429f168070d164b9ee05b261107a02bb50), the other one is a small refactoring to make things clearer.

## Before

<img width="748" alt="Screenshot 2019-09-17 at 22 08 34" src="https://user-images.githubusercontent.com/233676/65079776-c9c60e00-d997-11e9-83b2-b75c6e0d23df.png">

## After

<img width="748" alt="Screenshot 2019-09-17 at 22 07 48" src="https://user-images.githubusercontent.com/233676/65079758-c468c380-d997-11e9-8331-9016e3224c62.png">
