### PR TITLE
allow configuring footer_links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,17 @@ header_links:
   Documentation: /
 ```
 
+## `footer_links`
+
+Links to show in footer.
+
+Example:
+
+```yaml
+footer_links:
+  Accessibility: /accessibility
+```
+
 ## `host`
 
 Host to use for canonical URL generation (without trailing slash).

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -132,6 +132,17 @@ weight: 20
 ---
 ```
 
+## `hide_in_navigation`
+
+Set `hide_in_navigation: true` to prevent the page from being rendered in the
+main page tree navigation.
+
+```yaml
+---
+hide_in_navigation: true
+---
+```
+
 ## `parent`
 
 The page that should be highlighted as ‘active’ in the navigation.

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -14,6 +14,10 @@ header_links:
   Expired with owner: /expired-page-with-owner.html
   Not expired page: /not-expired-page.html
 
+footer_links:
+  Accessibility: /hidden-page.html
+  Hidden Page: /hidden-page.html
+
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:
 

--- a/example/source/hidden-page.html.md
+++ b/example/source/hidden-page.html.md
@@ -1,0 +1,10 @@
+---
+title: Hidden page
+hide_in_navigation: true
+---
+
+# This is a hidden page
+
+Sometimes you don't want a page to show up in main nagivation, for example,
+when you want to link to it from footer. Setting `hide_in_navigation: true`
+frontmatter will prevent a link being generated in the navigation.

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -34,6 +34,8 @@ module GovukTechDocs
         .sort_by { |r| [r.data.weight ? 0 : 1, r.data.weight || 0] }
         output = '';
         resources.each do |resource|
+          # Skip from page tree if hide_in_navigation:true frontmatter
+          next if resource.data.hide_in_navigation
           # Reuse the generated content for the active page
           # If we generate it twice it increments the heading ids
           content =

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -36,14 +36,14 @@ module GovukTechDocs
         resources.each do |resource|
           # Skip from page tree if hide_in_navigation:true frontmatter
           next if resource.data.hide_in_navigation
+
           # Reuse the generated content for the active page
           # If we generate it twice it increments the heading ids
-          content =
-            if current_page.url == resource.url && current_page_html
-              current_page_html
-            else
-              resource.render(layout: false)
-            end
+          content = if current_page.url == resource.url && current_page_html
+                      current_page_html
+                    else
+                      resource.render(layout: false)
+                    end
           # Avoid redirect pages
           next if content.include? "http-equiv=refresh"
 

--- a/lib/source/layouts/_footer.erb
+++ b/lib/source/layouts/_footer.erb
@@ -2,6 +2,16 @@
   <div class="govuk-footer__meta">
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
 
+      <% if config[:tech_docs][:footer_links] %>
+        <ul class="govuk-footer__inline-list">
+          <% config[:tech_docs][:footer_links].each do |title, path| %>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="<%= url_for path %>"><%= title %></a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
       <svg
         role="presentation"
         focusable="false"

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -91,6 +91,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
     class FakeData
       attr_reader :weight
       attr_reader :title
+      attr_reader :hide_in_navigation
       def initialize(weight = nil, title = nil)
         @weight = weight
         @title = title


### PR DESCRIPTION
## What

Allow configuring links that display in the footer of the core template form the config:

```
footer_links:
  Page Name: /page/link/url
```

To make this more practical, we also add support for skipping rendering a page in the page tree by setting
`hide_in_navigation: true` frontmatter.

## Why

Some pages (such as accessibility info, privacy info, etc) do not really fit in the main navigation, and we want a way to add this kind of information.