### PR TITLE
Pin openapi3_parser

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-search-gds"
   spec.add_dependency "nokogiri"
   spec.add_dependency "redcarpet", "~> 3.3.2"
-  spec.add_dependency "openapi3_parser"
+  spec.add_dependency "openapi3_parser", "~> 0.5.0"
   spec.add_dependency "pry"
 
 


### PR DESCRIPTION
The 0.6.0 release is causing builds to fail. Pinning it to 0.5.2 appears to solve this.

The maintainer of openapi3_parser has been made aware, and hopes to have a new version out soon.