### PR TITLE
Update openapi_parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [Pull request: #125: Fix API docs showing required properties as optional](https://github.com/alphagov/tech-docs-gem/pull/125)
+
 ## 2.2.0
 
 ### Accessibility Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,6 @@ You can look at the [2.0.6 milestone](https://github.com/alphagov/tech-docs-gem/
 
 ## 2.0.5
 
-
 Adds [new global configuration option](https://github.com/alphagov/tech-docs-gem/pull/122) that controls whether review banners appear or not at the bottom of pages when expiry dates are set in the frontmatter.
 
 [Fixes the hard-coded service link](https://github.com/alphagov/tech-docs-gem/pull/119) in the header.

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-sprockets", "~> 4.0.0"
   spec.add_dependency "middleman-syntax", "~> 3.2.0"
   spec.add_dependency "nokogiri"
-  spec.add_dependency "openapi3_parser", "~> 0.8.0"
+  spec.add_dependency "openapi3_parser", "~> 0.9.0"
   spec.add_dependency "pry"
   spec.add_dependency "redcarpet", "~> 3.5.0"
   spec.add_dependency "sass"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -42,12 +42,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-sprockets", "~> 4.0.0"
   spec.add_dependency "middleman-syntax", "~> 3.2.0"
   spec.add_dependency "nokogiri"
-  spec.add_dependency "openapi3_parser", "~> 0.5.0"
+  spec.add_dependency "openapi3_parser", "~> 0.8.0"
   spec.add_dependency "pry"
   spec.add_dependency "redcarpet", "~> 3.5.0"
   spec.add_dependency "sass"
   spec.add_dependency "sprockets", "~> 4.0.0"
-
 
   spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "byebug"

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -107,12 +107,6 @@ module GovukTechDocs
         @template_responses.result(binding)
       end
 
-      def markdown(text)
-        if text
-          Tilt["markdown"].new(context: @app) { text }.render
-        end
-      end
-
       def json_output(schema)
         properties = schema_properties(schema)
         JSON.pretty_generate(properties)

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -115,15 +115,10 @@ module GovukTechDocs
           end
         end
         properties.each do |property|
-          # Must be a schema be referenced by another schema
-          # And not a property of a schema
-          if property.node_context.referenced_by.to_s.include?("#/components/schemas") &&
-              !property.node_context.source_location.to_s.include?("/properties/")
-            schema_name = get_schema_name(property.node_context.source_location.to_s)
+          if property.name
+            schemas.push property.name
           end
-          if !schema_name.nil?
-            schemas.push schema_name
-          end
+
           # Check sub-properties for references
           schemas.concat(schemas_from_schema(property))
         end

--- a/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
@@ -1,5 +1,5 @@
 <h1 id="<%=  info.title.parameterize %>"><%= info.title %> v<%= info.version %></h1>
-<%= markdown(info.description) %>
+<%= info.description_html %>
 
 <% unless servers.empty? %>
   <h2 id="servers">Servers</h2>

--- a/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/api_reference_full.html.erb
@@ -1,7 +1,8 @@
 <h1 id="<%=  info.title.parameterize %>"><%= info.title %> v<%= info.version %></h1>
 <%= info.description_html %>
 
-<% unless servers.empty? %>
+<%# OpenAPI files default to having a single server of URL "/" %>
+<% if servers.length > 1 || servers[0].url != "/" %>
   <h2 id="servers">Servers</h2>
   <div id="server-list">
     <% servers.each do |server| %>

--- a/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/operation.html.erb
@@ -3,7 +3,7 @@
   <p><em><%= operation.summary %></em></p>
 <% end %>
 <% if operation.description %>
-  <p><%= markdown(operation.description) %></p>
+  <%= operation.description_html %>
 <% end %>
 
 <%= parameters %>

--- a/lib/govuk_tech_docs/api_reference/templates/parameters.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/parameters.html.erb
@@ -11,7 +11,7 @@
 <td><%= parameter.in %></td>
 <td><%= parameter.schema.type %></td>
 <td><%= parameter.required? %></td>
-<td><%= markdown(parameter.description) %>
+<td><%= parameter.description_html %>
 <% if parameter.schema.enum %>
 <p>Available items:</p>
 <ul>

--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -9,7 +9,7 @@
 <tr>
 <td><%= key %></td>
 <td>
-<%= markdown(response.description) %>
+<%= response.description_html %>
 <% if response.content['application/json']
 if response.content['application/json']["example"]
   request_body = json_prettyprint(response.content['application/json']["example"])

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -6,18 +6,18 @@
 <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
 </thead>
 <tbody>
-<% properties.each do |property| %>
+<% properties.each do |property_name, property_attributes| %>
 <tr>
-<td><%= property[0] %></td>
-<td><%= property[1].type %></td>
-<td><%= property[1].required.present? %></td>
-<td><%= property[1].description_html %></td>
+<td><%= property_name %></td>
+<td><%= property_attributes.type %></td>
+<td><%= property_attributes.required.present? %></td>
+<td><%= property_attributes.description_html %></td>
 <td>
   <%=
-  schema = property[1]
+  linked_schema = property_attributes
   # If property is an array, check the items property for a reference.
-  if property[1].type == 'array'
-    schema = property[1]['items']
+  if property_attributes.type == 'array'
+    linked_schema = property_attributes['items']
   end
   # Only print a link if it's a named schema
   get_schema_link(schema) if schema.name %>

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -19,8 +19,8 @@
   if property[1].type == 'array'
     schema = property[1]['items']
   end
-  # Only print a link if it's a referenced object.
-  get_schema_link(schema) if schema.node_context.referenced_by.to_s.include? '#/components/schemas' and !schema.node_context.source_location.to_s.include? '/properties/' %>
+  # Only print a link if it's a named schema
+  get_schema_link(schema) if schema.name %>
 </td>
 </tr>
 <% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -1,7 +1,7 @@
 <h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
 <%= schema.description_html %>
 <% if properties.any? %>
-<table>
+<table class='<%= id.parameterize %>'>
 <thead>
 <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th><th>Schema</th></tr>
 </thead>
@@ -10,7 +10,7 @@
 <tr>
 <td><%= property_name %></td>
 <td><%= property_attributes.type %></td>
-<td><%= property_attributes.required.present? %></td>
+<td><%= schema.requires?(property_name) %></td>
 <td><%= property_attributes.description_html %></td>
 <td>
   <%=
@@ -20,7 +20,7 @@
     linked_schema = property_attributes['items']
   end
   # Only print a link if it's a named schema
-  get_schema_link(schema) if schema.name %>
+  get_schema_link(linked_schema) if linked_schema.name %>
 </td>
 </tr>
 <% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -1,5 +1,5 @@
 <h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
-<%= markdown(schema.description) %>
+<%= schema.description_html %>
 <% if properties.any? %>
 <table>
 <thead>
@@ -11,7 +11,7 @@
 <td><%= property[0] %></td>
 <td><%= property[1].type %></td>
 <td><%= property[1].required.present? %></td>
-<td><%= markdown(property[1].description) %></td>
+<td><%= property[1].description_html %></td>
 <td>
   <%=
   schema = property[1]

--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -55,5 +55,7 @@ RSpec.describe "OpenAPI reference" do
     expect(page).to have_css("h3#schema-pet", text: "Pet")
     # Schema parameters
     expect(page).to have_css("table", text: /\b(tag )\b/)
+    # Check that the "required" column is true for the `id` attribute
+    expect(page).to have_css("table.schema-pet td:nth(3)", text: "true")
   end
 end


### PR DESCRIPTION
Following up from https://github.com/alphagov/tech-docs-gem/pull/121 this updates openapi_parser to allow the latest version of gem. Since the gem is below version 1 it seemed safe to maintain the pin.

I've also done some cleaning up of some of the Ruby code in `GovukTechDocs::ApiReference::Renderer` to make it more shorter and more consistent with modern Ruby. There's a few dubious things in there that I left as I didn't want to risk creating fresh bugs from "fixing" stuff.

I've also rebased https://github.com/alphagov/tech-docs-gem/pull/113 onto this as that fix would conflict with the changes here.

Edit:

Since opening this @tijmenb closed #113 so the link to that is no longer accurate. I didn't want to re-instate a bug by undoing that so wanted to keep that change here and had already amended his change to use a new method in openapi_parser to check required status.

To document the issue, an [OpenAPI document schema object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) has a required property which [must be an array of strings](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.15) which is used to indicate what properties of that object are required.

Previously the schema template just checked whether that array was set to determine if a parameter was required: https://github.com/alphagov/tech-docs-gem/blob/a2ba6143342ea9b58fef879a3946500fba71db23/lib/govuk_tech_docs/api_reference/templates/schema.html.erb#L13
This is incorrect as this only tells you whether that parameter requires properties of its own.

Instead we use the [`#requires?`](https://www.rubydoc.info/github/kevindew/openapi3_parser/Openapi3Parser/Node/Schema#requires%3F-instance_method) method on the schema to determine if this property is required.