### PR TITLE
`tech-docs-monitor` is the correct repo for Daniel the Manual Spaniel

### DIFF
--- a/docs/page-expiry.md
+++ b/docs/page-expiry.md
@@ -80,5 +80,5 @@ default_owner_slack: '#owner'
 
 The expiry date for each page is also shown in the `/api/pages.json`
 representation of all pages.  This is used by the
-[tech-docs-notifier](https://github.com/alphagov/tech-docs-notifier) to post
+[tech-docs-monitor](https://github.com/alphagov/tech-docs-monitor) to post
 messages to Slack when pages have expired.


### PR DESCRIPTION
## What

The link to Daniel the Manual Spaniel's repo is broken: https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/#page-api

This is because it's set to tech-docs-notifier instead of tech-docs-**monitor**. 

This PR replaces 'notifier' with 'monitor' to fix the broken link.

## Why

Fixes alphagov/tdt-documentation#90