### PR TITLE
Update multi-page navigation to allow custom path prefix

### DIFF
--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -55,22 +55,18 @@ module GovukTechDocs
           # prefix in to consideration when checking for the root index.html.
           # The prefix may be set with or without a trailing slash: make sure
           # it has one for this comparison check.
-          home_url =
-            if config[:http_prefix].end_with?("/")
-              config[:http_prefix]
-            else
-              config[:http_prefix] + "/"
-            end
+          home_url = config[:http_prefix].end_with?("/") ? config[:http_prefix] : config[:http_prefix] + "/"
+          resource_url = config[:tech_docs][:path_prefix] ? config[:tech_docs][:path_prefix] + resource.url : resource.url
 
-          if resource.children.any? && resource.url != home_url
-            output += %{<ul><li><a href="#{resource.url}"><span>#{resource.data.title}</span></a>\n}
+          if resource.children.any? && resource_url != home_url
+            output += %{<ul><li><a href="#{resource_url}"><span>#{resource.data.title}</span></a>\n}
             output += render_page_tree(resource.children, current_page, config, current_page_html)
             output += "</li></ul>"
-          else
+          elsif resource.path.end_with?(".html")
             output +=
               single_page_table_of_contents(
                 content,
-                url: resource.url,
+                url: resource_url,
                 max_level: config[:tech_docs][:max_toc_heading_level],
               )
           end


### PR DESCRIPTION
Currently if the tech-docs is deployed on a path (e.g. `https://alphagov.github.io/api-catalogue/`) the navigation links are broken as they are generated from root (`/`). One way to avoid this without affecting current single-page or multi-page configuration is to define a `path_prefix` in config that is prepended to each link.

This is an attempt to fix #128 which is currently blocking any deployment for the [api-catalogue](https://github.com/alphagov/api-catalogue).

I'm open to any other suggestions that will unblock this - especially since I'm not familiar with this project or Middleman.

Note: I needed to refactor the conditional statements as linter was complaining about the code having too many lines (`Metrics/BlockLength: Block has too many lines. [31/25]`)