### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 Layout/IndentHeredoc:
   Enabled: false
 
@@ -5,7 +9,4 @@ Naming/HeredocDelimiterNaming:
   Enabled: false
 
 Lint/NestedMethodDefinition:
-  Enabled: false
-
-Performance/HashEachMethods:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Use of  `govuk-lint` replaced with `rubocop-govuk` due to the former [becoming deprecated](https://github.com/alphagov/govuk-lint/pull/133).
+
 ## 2.0.7
 
 A small release to fix an issue where code blocks font size was too large on some browsers.

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:spec)
 load "jasmine/tasks/jasmine.rake"
 
 task :lint do
-  sh "govuk-lint-ruby example lib spec Rakefile"
+  sh "rubocop example lib spec Rakefile"
   sh "npm run lint --silent"
 end
 

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "capybara", "~> 2.18.0"
-  spec.add_development_dependency "govuk-lint", "~> 4.1.0"
+  spec.add_development_dependency "rubocop-govuk", "~> 1.0.0"
   spec.add_development_dependency "jasmine", "~> 3.1.0"
   spec.add_development_dependency "rspec", "~> 3.7.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly with a set of shared configs.
- See alphagov/govuk-rfcs/pull/100 for more context.