### PR TITLE
Reset `table-layout` to `auto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-Remove the `table-layout: fixed` style from the tables in tech' docs content, mainly due to it
-causing https://github.com/alphagov/tech-docs-gem/issues/133.
+Change how tables are laid out to fix https://github.com/alphagov/tech-docs-gem/issues/133.
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-Change how tables are laid out to fix https://github.com/alphagov/tech-docs-gem/issues/133.
+Change how tables are laid out to fix some content in Notify tech' docs being squashed due to its
+column having a fixed width.
+
+Related issue: https://github.com/alphagov/tech-docs-gem/issues/133
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+Remove the `table-layout: fixed` style from the tables in tech' docs content, mainly due to it
+causing https://github.com/alphagov/tech-docs-gem/issues/133.
+
 ## 2.0.8
 
 Use of  `govuk-lint` replaced with `rubocop-govuk` due to the former [becoming deprecated](https://github.com/alphagov/govuk-lint/pull/133).

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -77,7 +77,6 @@
 
   table {
     @include govuk-responsive-margin(6, "bottom");
-    table-layout: fixed;
   }
 
   pre + h2 {


### PR DESCRIPTION
This removes the `table-layout: fixed` style for tables in tech' docs content, introduced as part of https://github.com/alphagov/tech-docs-gem/commit/ffa22615851866bb7052a87285fca30273f0ac54. 

## Why did we fix our table layouts?

It was introduced as part of a pull request that made 2 changes:
1. the `max-width: 40em` for `<pre>` blocks was removed to stop [issue #100](https://github.com/alphagov/tech-docs-gem/issues/100)
2. `table-layout: fixed` was added to fix the problems `max-width: 40em` solved

## Why did we constrain the width of our `<pre>` tags?

The comments above `max-width: 40em` mention `<pre>` tags pushing tables to be larger than the main column (see https://github.com/alphagov/tech-docs-gem/commit/ffa22615851866bb7052a87285fca30273f0ac54#diff-d7f12a4697fd2195a8c62339caee5c77L122).

## Why should be revert to auto-sized layouts?

### 1. It causes an issue with existing tables

It created [issue #133](https://github.com/alphagov/tech-docs-gem/issues/133) with Notify's tech' docs.

### 2. Removing it shouldn't effect any other existing tables

I went through the main users of this gem and found all the tables in them (thanks @nickcolley for their details):

https://docs.google.com/spreadsheets/d/1OZGQifZIw0I2GXqmrp78DoI3R2sfcxn5IcFq3Y5RXqA/edit#gid=0

I can't find any tables that use `<pre>` tags in table cells, just inline `<code>` blocks.

I also tested all these tables without `table-layout: fixed` and none of them displayed in ways that distorted the content or made the table wider than the main column.

### 3. Tables that are too wide don't break the main column

Tables are wrapped in a fixed-width container which scrolls. This means that if they're wider than the main column they don't break it and users can scroll to access their content. For example:

https://www.docs.verify.service.gov.uk/legacy/build-ms/msa/#msa-tls-certificates

### We probably shouldn't be using block-level code in tables

Note: this point is just my opinion 🙂.

Middleman's markdown parser [Redcarpet uses PHP-Markdown style tables](https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use. In its docs, PHP-Markdown says it allows 'span level formatting' in its tables:

https://michelf.ca/projects/php-markdown/extra/#table

There's no mention of official support for block-level formatting, like `<pre>`.