### PR TITLE
Ensure the page can be pinch to zoomed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Unreleased
 
-Change how tables are laid out to fix some content in Notify tech' docs being squashed due to its
-column having a fixed width.
+### Fixes
 
-Related issue: https://github.com/alphagov/tech-docs-gem/issues/133
+- [Pull request #154: Fix table columns breaking content](https://github.com/alphagov/tech-docs-gem/pull/154).
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [Pull request #154: Fix table columns breaking content](https://github.com/alphagov/tech-docs-gem/pull/154).
+- [Pull request #155: Ensure the page can be pinch to zoomed](https://github.com/alphagov/tech-docs-gem/pull/155).
 
 ## 2.0.8
 

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <% if config[:tech_docs][:prevent_indexing] %>
       <meta name="robots" content="noindex">
     <% end %>


### PR DESCRIPTION
We have intentionally tried to disable pinch to zoom in the past based around the sticky navigation, but this is an accessibility issue.
This pull request updates this decision to pinch to zooming, which for the most part is how it's working at the moment anyway since a lot of devices ignore blocking pinch to zoom.

I've tested in latest versions of iOS and Android.

- iOS v10 onwards ignores disabling pinch to zoom
- Android does not ignore disabling pinch to zoom, although the user can override this.

I have not been able to introduce any negative impact for allowing pinch to zoom, the interface scales proportionally and does not obstruct anything. So given that iOS already ignores this I think we should allow this for all users.

This is also a WCAG accessibility requirement.

Fixes https://github.com/alphagov/tech-docs-gem/issues/110