### PR TITLE
Make sure IDs on collapsible navigation are unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [Pull request #160: Make sure IDs on collapsible navigation are unique](https://github.com/alphagov/tech-docs-gem/pull/160)
+
 ## 2.0.9
 
 ### Fixes

--- a/example/source/nested-page/another-nested-nested-page/index.html.md
+++ b/example/source/nested-page/another-nested-nested-page/index.html.md
@@ -1,0 +1,5 @@
+---
+title: Another nested nested page
+---
+
+# Another nested nested page

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -28,13 +28,16 @@
           continue
         }
         $topLevelItem.addClass('collapsible')
+        var arrayOfIds = []
         $listing.each(function (i) {
+          var uniqueId = id + '-' + i
+          arrayOfIds.push(uniqueId)
           $(this).addClass('collapsible__body')
-            .attr('id', id + '-' + i)
+            .attr('id', uniqueId)
             .attr('aria-expanded', 'false')
         })
         $heading.addClass('collapsible__heading')
-          .after('<button class="collapsible__toggle" aria-controls="' + id + '"><span class="collapsible__toggle-label">Expand ' + $heading.text() + '</span><span class="collapsible__toggle-icon" aria-hidden="true"></button>')
+          .after('<button class="collapsible__toggle" aria-controls="' + arrayOfIds.join(' ') + '"><span class="collapsible__toggle-label">Expand ' + $heading.text() + '</span><span class="collapsible__toggle-icon" aria-hidden="true"></button>')
         $topLevelItem.on('click', '.collapsible__toggle', function (e) {
           e.preventDefault()
           var $parent = $(this).parent()

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -28,9 +28,11 @@
           continue
         }
         $topLevelItem.addClass('collapsible')
-        $listing.addClass('collapsible__body')
-          .attr('id', id)
-          .attr('aria-expanded', 'false')
+        $listing.each(function (i) {
+          $(this).addClass('collapsible__body')
+            .attr('id', id + '-' + i)
+            .attr('aria-expanded', 'false')
+        })
         $heading.addClass('collapsible__heading')
           .after('<button class="collapsible__toggle" aria-controls="' + id + '"><span class="collapsible__toggle-label">Expand ' + $heading.text() + '</span><span class="collapsible__toggle-icon" aria-hidden="true"></button>')
         $topLevelItem.on('click', '.collapsible__toggle', function (e) {

--- a/spec/javascripts/collapsible-navigation-spec.js
+++ b/spec/javascripts/collapsible-navigation-spec.js
@@ -1,0 +1,35 @@
+describe('Collapsible navigation', function () {
+  'use strict'
+
+  var module
+  var $navigation
+
+  beforeEach(function () {
+    module = new GOVUK.Modules.CollapsibleNavigation()
+    $navigation = $(`
+      <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading" data-module="collapsible-navigation">
+        <ul>
+          <li>
+            <a href="/nested-page/"><span>Nested page</span></a>
+            <ul>
+              <li>
+                <a href="/nested-page/another-nested-page/#another-nested-page"><span>Another nested page</span></a>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <a href="/nested-page/another-nested-nested-page/#another-nested-nested-page"><span>Another nested nested page</span></a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>`)
+    module.start($navigation)
+  })
+
+  it('sanitizes headings to unique IDs correctly', function () {
+    $navigation.find('ul > li > ul').each(function (i) {
+      expect($(this)[0].id).toEqual('toc-nested-page-' + i)
+    })
+  })
+})

--- a/spec/javascripts/collapsible-navigation-spec.js
+++ b/spec/javascripts/collapsible-navigation-spec.js
@@ -6,30 +6,36 @@ describe('Collapsible navigation', function () {
 
   beforeEach(function () {
     module = new GOVUK.Modules.CollapsibleNavigation()
-    $navigation = $(`
-      <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading" data-module="collapsible-navigation">
-        <ul>
-          <li>
-            <a href="/nested-page/"><span>Nested page</span></a>
-            <ul>
-              <li>
-                <a href="/nested-page/another-nested-page/#another-nested-page"><span>Another nested page</span></a>
-              </li>
-            </ul>
-            <ul>
-              <li>
-                <a href="/nested-page/another-nested-nested-page/#another-nested-nested-page"><span>Another nested nested page</span></a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </nav>`)
+    $navigation = $(
+      '<nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading" data-module="collapsible-navigation">' +
+        '<ul>' +
+          '<li>' +
+            '<a href="/nested-page/"><span>Nested page</span></a>' +
+            '<ul>' +
+              '<li>' +
+                '<a href="/nested-page/another-nested-page/#another-nested-page"><span>Another nested page</span></a>' +
+              '</li>' +
+            '</ul>' +
+            '<ul>' +
+              '<li>' +
+                '<a href="/nested-page/another-nested-nested-page/#another-nested-nested-page"><span>Another nested nested page</span></a>' +
+              '</li>' +
+            '</ul>' +
+          '</li>' +
+        '</ul>' +
+      '</nav>')
     module.start($navigation)
   })
 
   it('sanitizes headings to unique IDs correctly', function () {
     $navigation.find('ul > li > ul').each(function (i) {
       expect($(this)[0].id).toEqual('toc-nested-page-' + i)
+    })
+  })
+
+  it('aria-controls on the button lists all the nested IDs', function () {
+    $navigation.find('button').each(function (i) {
+      expect($navigation.find('button').attr('aria-controls')).toEqual('toc-nested-page-0 toc-nested-page-1')
     })
   })
 })


### PR DESCRIPTION
Multiple nested pages were getting assigned the same ID (from the parent). This change
appends the iterator index to the elements to make sure they're unique.
Also added an extra nested page to the example docs and a test.