### PR TITLE
Fix line height spacing for multiline code elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #162: Fix line height spacing for multiline code elements](https://github.com/alphagov/tech-docs-gem/pull/162)
+- [Pull request #165: Update header alignment to match layout](https://github.com/alphagov/tech-docs-gem/pull/165)
+
 ## 2.0.10
+
+### Fixes
 
 - [Pull request #160: Make sure IDs on collapsible navigation are unique](https://github.com/alphagov/tech-docs-gem/pull/160)
 

--- a/example/source/code.html.md
+++ b/example/source/code.html.md
@@ -8,6 +8,35 @@ A paragraph with a `code` element within it.
 
 <a href="#"><code>code element within a link</code></a>
 
+An example of a table with a `code` element within it.
+
+<div class="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th style="text-align:left">httpResult</th>
+        <th style="text-align:left">Message</th>
+        <th style="text-align:left">How to fix</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="text-align:left"><code>400</code></td>
+        <td style="text-align:left">
+          <code>[{</code>
+          <br />
+          <code>"error": "BadRequestError",</code>
+          <br />
+          <code>"message": "Can't send to this recipient using a team-only API key"</code>
+          <br />
+          <code>]}</code>
+        </td>
+        <td style="text-align:left">Use the correct type of API key</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 An example of a code block with a long line length
 
 ```ruby

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -139,6 +139,8 @@
     font-family: monaco, Consolas, "Lucida Console", monospace;
     font-size: 15px;
     font-size: 0.9375rem;
+    // Match the line-height outside of tables
+    line-height: 1.4;
     color: $code-0E;
 
     @include govuk-media-query(tablet) {


### PR DESCRIPTION
Text in our `<code>` elements is larger than the default Transport font on OSX, due to it using the Monaco font. This creates a taller formatting box for each line of text it has.

We set a smaller font-size, and line-height in `<td>`s. This works for Transport but text in `<code>` sections appears squashed vertically.

This sets the line-height for `<code>` to match that of content outside tables, to stop it
squashing up.

This has been tested with Consolas (the font Windows uses for `<code>`) and all other
fallbacks.

Here's an idea of the changes this introduces, viewed on OSX Firefox.

### Before

<img width="507" alt="image" src="https://user-images.githubusercontent.com/87140/68961431-4cb5ea00-07ca-11ea-8df7-b503a2ebe282.png">

## After

<img width="501" alt="image" src="https://user-images.githubusercontent.com/87140/68961418-4162be80-07ca-11ea-8f4c-8b84e5146443.png">
