### PR TITLE
Update header alignment to match layout

### DIFF
--- a/lib/assets/stylesheets/_core.scss
+++ b/lib/assets/stylesheets/_core.scss
@@ -6,6 +6,7 @@
 @import "modules/anchored-heading";
 @import "modules/app-pane";
 @import "modules/footer";
+@import "modules/header";
 @import "modules/page-review";
 @import "modules/search";
 @import "modules/contribution-banner";

--- a/lib/assets/stylesheets/modules/_header.scss
+++ b/lib/assets/stylesheets/modules/_header.scss
@@ -1,0 +1,7 @@
+.app-header {
+  // Adjust the padding on the header container so that it matches the custom sidebar.
+  .govuk-header__container--full-width {
+    @include govuk-responsive-padding(6, "left");
+    @include govuk-responsive-padding(6, "right");
+  }
+}

--- a/lib/assets/stylesheets/modules/_header.scss
+++ b/lib/assets/stylesheets/modules/_header.scss
@@ -4,4 +4,13 @@
     @include govuk-responsive-padding(6, "left");
     @include govuk-responsive-padding(6, "right");
   }
+  // Give the product name in the header more space so it does not wrap early on smaller screens.
+  @include govuk-media-query($from: desktop) {
+    .govuk-header__logo {
+      width: 45%;
+    }
+    .govuk-header__content {
+      width: 55%;
+    }
+  }
 }

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -43,7 +43,7 @@ html.has-search-results-open {
     -webkit-overflow-scrolling: touch;
     -ms-overflow-style: none;
     @include govuk-media-query(tablet) {
-      padding: 22px 20px 0 30px;
+      padding: govuk-spacing(6);
       top: 0;
       // The width of the sidebar
       left: 330px;

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -8,9 +8,7 @@
   color:  $govuk-text-colour;
 
   @include govuk-media-query(tablet) {
-    // We add 2 pixels to the gutter here to ensure there's sufficient spacing between
-    // an anchor link (see _anchored-heading.scss) on a heading and the left-hand pane.
-    margin: 0 govuk-spacing(6) (govuk-spacing(6) + 2px);
+    margin: 0 govuk-spacing(6) govuk-spacing(6);
   }
 
   .has-search-results-open & {

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -18,7 +18,7 @@
         a:link, a:visited {
           display: block;
           position: relative;
-          padding: 8px govuk-spacing(6) 8px govuk-spacing(3);
+          padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
           margin: 0 -1 * govuk-spacing(3);
           border-left: 5px solid transparent;
           text-decoration: none;
@@ -93,7 +93,7 @@
 
   @include govuk-media-query(tablet) {
     .toc {
-      padding: 22px govuk-spacing(6) govuk-spacing(3)
+      padding: govuk-spacing(5) govuk-spacing(6);
     }
 
     // Prevent the fixedsticky spacer from appearing if the browser is resized

--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header " role="banner" data-module="govuk-header">
+<header class="govuk-header app-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-header__container--full-width">
     <div class="govuk-header__logo">
       <% if config[:tech_docs][:service_link] %>


### PR DESCRIPTION
This pull request aims to address some spacing issues introduced when this format was updated to use the GOV.UK Design System by aligning the header and layout elements on the page.

It also expands the width of the area for the product name which stops it wrapping early, this is something we might want to consider pushing upstream to GOV.UK Frontend in the future.

| Full size before | Full size after |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/69167054-2eaef900-0aec-11ea-88eb-7e195f5dd67a.png) | ![](https://user-images.githubusercontent.com/2445413/69168607-e80ece00-0aee-11ea-8138-fd56f2810ffa.png) |

| Smaller before | Smaller after |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/69167215-7afa3900-0aec-11ea-8424-e21b3acd5c07.png) | ![](https://user-images.githubusercontent.com/2445413/69168893-5a7fae00-0aef-11ea-97af-5b0074dd8055.png) |

| Even smaller before | Even smaller after |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/69167239-88172800-0aec-11ea-93f7-9199f76b7dd9.png) | ![](https://user-images.githubusercontent.com/2445413/69168866-518edc80-0aef-11ea-877f-a739a531240b.png) |





Fixes https://github.com/alphagov/tech-docs-gem/issues/164