### PR TITLE
Allow additional markdown options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #162: Fix line height spacing for multiline code elements](https://github.com/alphagov/tech-docs-gem/pull/162)
+- [Pull request #165: Update header alignment to match layout](https://github.com/alphagov/tech-docs-gem/pull/165)
+
 ## 2.0.11
 
 ### Fixes

--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -52,3 +52,7 @@ api_path: source/pets.yml
 # Optional global settings for the page review process
 owner_slack_workspace: gds
 default_owner_slack: '#2nd-line'
+
+# Markdown options
+markdown:
+  disable_indented_code_blocks: true

--- a/example/source/code.html.md
+++ b/example/source/code.html.md
@@ -8,7 +8,7 @@ A paragraph with a `code` element within it.
 
 <a href="#"><code>code element within a link</code></a>
 
-An example of a table with a `code` element within it.
+## Table with a `code` element within it.
 
 <div class="table-container">
   <table>
@@ -37,7 +37,7 @@ An example of a table with a `code` element within it.
   </table>
 </div>
 
-An example of a code block with a long line length
+## Code block with a long line length
 
 ```ruby
 RSpec.describe ContentItem do
@@ -56,9 +56,14 @@ RSpec.describe ContentItem do
 end
 ```
 
-An example of a code block with a short length
+## Fenced code block with a short length
 
 ```ruby
 RSpec.describe ContentItem do
 end
 ```
+
+## Indented code block
+
+    RSpec.describe ContentItem do
+    end

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -40,15 +40,19 @@ module GovukTechDocs
     context.files.watch :source, path: "#{__dir__}/source"
 
     context.set :markdown_engine, :redcarpet
-    context.set :markdown,
-                renderer: TechDocsHTMLRenderer.new(
-                  with_toc_data: true,
-                  api: true,
-                  context: context,
-                ),
-                fenced_code_blocks: true,
-                tables: true,
-                no_intra_emphasis: true
+
+    default_markdown_options = {
+      renderer: TechDocsHTMLRenderer.new(
+        with_toc_data: true,
+        api: true,
+        context: context,
+      ),
+      fenced_code_blocks: true,
+      tables: true,
+      no_intra_emphasis: true
+    }
+    markdown_options = options[:markdown] || {}
+    context.set :markdown, default_markdown_options.merge(markdown_options)
 
     # Reload the browser automatically whenever files change
     context.configure :development do

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -30,6 +30,9 @@ module GovukTechDocs
   # @option options [Hash] livereload Options to pass to the `livereload`
   #   extension. Hash with symbols as keys.
   def self.configure(context, options = {})
+    config_file = ENV.fetch("CONFIG_FILE", "config/tech-docs.yml")
+    context.config[:tech_docs] = YAML.load_file(config_file).with_indifferent_access
+
     context.activate :sprockets
 
     context.sprockets.append_path File.join(__dir__, "../node_modules/govuk-frontend/")
@@ -51,7 +54,7 @@ module GovukTechDocs
       tables: true,
       no_intra_emphasis: true
     }
-    markdown_options = options[:markdown] || {}
+    markdown_options = context.config[:tech_docs][:markdown].transform_keys(&:to_sym) || {}
     context.set :markdown, default_markdown_options.merge(markdown_options)
 
     # Reload the browser automatically whenever files change
@@ -64,8 +67,6 @@ module GovukTechDocs
       activate :minify_javascript, ignore: ["/raw_assets/*"]
     end
 
-    config_file = ENV.fetch("CONFIG_FILE", "config/tech-docs.yml")
-    context.config[:tech_docs] = YAML.load_file(config_file).with_indifferent_access
     context.activate :unique_identifier
     context.activate :warning_text
     context.activate :api_reference


### PR DESCRIPTION
I think turning on new features may be too controversial so I'm adding functionality so the user can set their own preferences.

See https://github.com/alphagov/tech-docs-gem/issues/169 for why I want to do this.