### PR TITLE
OpenAPI renderer renders first anyOf example

### DIFF
--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -163,7 +163,7 @@ module GovukTechDocs
       end
 
       def json_output(schema)
-        properties =  schema_properties(schema)
+        properties = schema_properties(schema)
         JSON.pretty_generate(properties)
       end
 
@@ -179,6 +179,7 @@ module GovukTechDocs
           end
         end
         properties.merge! get_all_of_hash(schema_data)
+        properties.merge! get_any_of_hash(schema_data)
         properties_hash = Hash.new
         properties.each do |pkey, property|
           if property.type == "object"
@@ -237,6 +238,19 @@ module GovukTechDocs
             schema_nested.properties.each do |key, property|
               properties[key] = property
             end
+          end
+        end
+        properties
+      end
+
+      def get_any_of_hash(schema)
+        properties = Hash.new
+        any_of = schema["anyOf"]
+
+        if any_of.present?
+          nested_schema = any_of.first
+          nested_schema.properties.each do |key, property|
+            properties[key] = property
           end
         end
         properties

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -2,7 +2,6 @@ require "json"
 require "capybara/rspec"
 require "govuk_tech_docs/api_reference/api_reference_renderer"
 
-
 RSpec.describe GovukTechDocs::ApiReference::Renderer do
   describe ".api_full" do
     before(:each) do
@@ -12,7 +11,56 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
           "title": "title",
           "version": "0.0.1",
         },
-        "paths": {},
+        "paths": {
+          "/widgets": {
+            "get": {
+              "responses": {
+                "200": {
+                  "description": "description goes here",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/widgets"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "components": {
+          "schemas": {
+            "widgets": {
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/widget"
+                  }
+                }
+              }
+            },
+            "widget": {
+              "anyOf": [
+               { "$ref": "#/components/schemas/widgetInteger" },
+               { "$ref": "#/components/schemas/widgetString" },
+              ],
+            },
+            "widgetInteger": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer", example: 12345 }
+              }
+            },
+            "widgetString": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string", example: "abcde" }
+              }
+            }
+          }
+        }
       }
     end
 
@@ -58,6 +106,21 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
       expect(rendered).to have_css("div#server-list>p>strong", text: "Production")
       expect(rendered).to have_css("div#server-list>a", text: "https://dev.example.com")
       expect(rendered).to have_css("div#server-list>p>strong", text: "Development")
+    end
+
+    describe '#json_output' do
+      let(:document) { Openapi3Parser.load(@spec) }
+
+      subject { described_class.new(nil, document) }
+
+      it 'renders first anyOf reference example' do
+        schema = document.paths["/widgets"].get.node_data["responses"]["200"]["content"]["application/json"]["schema"]
+
+        json = subject.json_output(schema)
+        hash = JSON.parse(json)
+
+        expect(hash).to eql({"data"=>[{"id"=>12345}]})
+      end
     end
   end
 end


### PR DESCRIPTION
- Previously `anyOf` references were not handled
- This meant renderer would simply render `{}`
- Unlike `allOf` we do not know which schema to use for the example so
we simply pick the first one
- This mimics the behaviour seen in swagger