### PR TITLE
Use correct separator for page titles

### DIFF
--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -25,7 +25,7 @@ module GovukTechDocs
     end
 
     def browser_title
-      [page_title, site_name].select(&:present?).uniq.join(" | ")
+      [page_title, site_name].select(&:present?).uniq.join(" - ")
     end
 
     def canonical_url

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "The tech docs template" do
   end
 
   def and_there_are_proper_meta_tags
-    expect(page).to have_title "GOV.UK Documentation Example | My First Service"
+    expect(page).to have_title "GOV.UK Documentation Example - My First Service"
     expect(page).to have_css 'meta[property="og:site_name"]', visible: false
   end
 

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GovukTechDocs::MetaTags do
     it "combines the page title and service name" do
       browser_title = generate_title(site_name: "Test Site", page_title: "The Title")
 
-      expect(browser_title).to eql("The Title | Test Site")
+      expect(browser_title).to eql("The Title - Test Site")
     end
 
     it "does not duplicate the page title" do
@@ -56,7 +56,7 @@ RSpec.describe GovukTechDocs::MetaTags do
         "twitter:card" => "summary",
         "twitter:domain" => "www.example.org",
         "twitter:image" => "https://www.example.org/images/govuk-large.png",
-        "twitter:title" => "The Title | Test Site",
+        "twitter:title" => "The Title - Test Site",
         "twitter:url" => "https://www.example.org/foo.html")
     end
 


### PR DESCRIPTION
Use a hyphen (`-`) rather than a pipe (`|`) within page titles to be consistent with [the guidance in the Service Manual](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#headings-and-title):

> The <title> should be based on the `<h1>`, and follow this format:
>
> Where do you live? - register to vote - GOV.UK