### PR TITLE
Update to latest bundler version

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
 
 
-  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "capybara", "~> 2.18.0"
   spec.add_development_dependency "rubocop-govuk", "~> 1.0.0"


### PR DESCRIPTION
This will hopefully fix errors seen on CI and locally:

> Bundler could not find compatible versions for gem "bundler":
>  In Gemfile:
>     bundler (~> 2.0.1)
>   Current Bundler version:
>     bundler (2.1.4)
> This Gemfile requires a different version of Bundler.
> Perhaps you need to update Bundler by running `gem install bundler`?