### PR TITLE
Use current markup for header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [Pull request #179: Use current markup for header and footer](https://github.com/alphagov/tech-docs-gem/pull/179)
 - [Pull request #178: Update dependencies and fix tests](https://github.com/alphagov/tech-docs-gem/pull/178) – includes updating GOV.UK Frontend to v3.6.0.
 
 ## 2.0.11

--- a/lib/source/layouts/_footer.erb
+++ b/lib/source/layouts/_footer.erb
@@ -13,7 +13,7 @@
       <% end %>
 
       <svg
-        role="presentation"
+        aria-hidden="true"
         focusable="false"
         class="govuk-footer__licence-logo"
         xmlns="http://www.w3.org/2000/svg"

--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -9,7 +9,7 @@
         <% if config[:tech_docs][:show_govuk_logo] %>
         <span class="govuk-header__logotype">
           <svg
-            role="presentation"
+            aria-hidden="true"
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"
@@ -42,7 +42,7 @@
     </div>
     <% if config[:tech_docs][:header_links] %>
     <div class="govuk-header__content">
-      <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
       <nav>
         <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
           <% config[:tech_docs][:header_links].each do |title, path| %>


### PR DESCRIPTION
Updates the tech docs to use the latest markup from the Design System