### PR TITLE
Update orange code highlight colour to meet minimum AA colour contrast ratio criterion

### DIFF
--- a/lib/assets/stylesheets/palette/_syntax-highlighting.scss
+++ b/lib/assets/stylesheets/palette/_syntax-highlighting.scss
@@ -10,7 +10,7 @@ $code-05:  $govuk-text-colour; /* Default Foreground, Caret, Delimiters, Operato
 $code-06: #ffffff; /* Light Foreground (Unused) */
 $code-07: #ffffff; /* Light Background (Unused) */
 
-$code-08: #B26749; /* Variables, XML Tags, Markup Link Text, Markup Lists */
+$code-08: #d4351c; /* Variables, XML Tags, Markup Link Text, Markup Lists */
 $code-09: #0E7754; /* Integers, Boolean, Constants, XML Attributes, Markup Link Url */
 $code-0A: #4C4077; /* Classes, Markup Bold, Search Text Background */
 $code-0B: $govuk-brand-colour; /* Strings, Inherited Class, Markup Code */


### PR DESCRIPTION
## What 
Update orange code highlight colour to meet minimum AA colour contrast ratio criterion

Had to use a custom colour as `govuk-colour("orange")` - `#f47738` doesn't meet the AA contrast ratio requirement when on light grey code background.

## Visual change

### Before

<img width="767" alt="before" src="https://user-images.githubusercontent.com/3758555/88657495-ee1b6c80-d0c9-11ea-9a37-3d2c64538a8c.png">


### With govuk-colour("orange")

<img width="812" alt="with-govuk-orange" src="https://user-images.githubusercontent.com/3758555/88657499-eeb40300-d0c9-11ea-9f40-c3407b167ff2.png">

### After

<img width="863" alt="after-with-custom-orange" src="https://user-images.githubusercontent.com/3758555/88657492-ecea3f80-d0c9-11ea-9418-5c7e19915752.png">
