### PR TITLE
Search: Support Github pages / http_prefix

### DIFF
--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -16,6 +16,7 @@
     var results
     var query
     var maxSearchEntries = 20
+    var searchIndexPath
 
     this.start = function start ($element) {
       $searchForm = $element.find('form')
@@ -25,6 +26,7 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
+      searchIndexPath = $element.data('searchIndexPath')
 
       changeSearchAction()
       changeSearchLabel()
@@ -49,7 +51,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search results')
       $.ajax({
-        url: '/search.json',
+        url: searchIndexPath,
         cache: true,
         method: 'GET',
         success: function (data) {

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search">
+<div class="search" data-module="search" data-search-index-path="<%= search_index_path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">


### PR DESCRIPTION
Hello 👋 . I'm working on the [API catalogue](https://github.com/alphagov/api-catalogue) with the DSA team. We use the marvellous `tech-docs-gem` to build the site, which is then currently deployed to Github pages.

## Context

For repo-specific Github pages, the site is deployed with the repo name prefixed in the path, e.g. `https://alphagov.github.io/api-catalogue/`. We'd like to use Middleman's [`http_prefix`](https://rubydoc.info/github/middleman/middleman/Middleman/Application#http_prefix-instance_method) option to account for this path prefix, which will allow us to simplify and automate  our build process.

Unfortunately with `http_prefix` configured the search doesn't work at the moment. Browsing `/api-catalogue/index.html` leads to a `404 Not found` for `/search.json` (the asset is actually located at `/api-catalogue/search.json`).

## Fix

Switches to use the `search_index_path` helper provided by the Middleman search gem itself, rather than hardcoding `/search.json`. This helper accounts for the `http_prefix` setting.

References:

- https://github.com/manastech/middleman-search#asset-pipeline
- https://github.com/manastech/middleman-search/blob/ed9e5254bb554988c755fc40238d9e9f67b20abe/lib/middleman-search/extension.rb#L29