### PR TITLE
Assets: Support Github pages / http_prefix

### DIFF
--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -1,4 +1,4 @@
-$govuk-assets-path: "/assets/govuk/assets/";
+$govuk-assets-path: "/assets/govuk/assets/" !default;
 
 // Include only the bits of GOV.UK Frontend we need
 $govuk-new-link-styles: true;

--- a/lib/assets/stylesheets/modules/_anchored-heading.scss
+++ b/lib/assets/stylesheets/modules/_anchored-heading.scss
@@ -18,12 +18,12 @@
     text-decoration: none;
     text-indent: -9999em;
 
-    background-image: url('/images/anchored-heading-icon.png');
+    background-image: image-url('/images/anchored-heading-icon.png');
     background-repeat: no-repeat;
     background-position: center center;
 
     @include govuk-device-pixel-ratio {
-      background-image: url('/images/anchored-heading-icon-2x.png');
+      background-image: image-url('/images/anchored-heading-icon-2x.png');
       background-size: $icon-width $icon-height;
     }
 

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -36,7 +36,7 @@ $input-size: 40px;
   padding: 0;
   width: $input-size;
   height: 100%;
-  background-image: url('/images/search-button.png');
+  background-image: image-url('/images/search-button.png');
   background-repeat: no-repeat;
   background-position: 2px 50%;
   text-indent: -5000px;
@@ -104,7 +104,7 @@ $input-size: 40px;
       left: -9px;
       width: 10px;
       height: 20px;
-      background: no-repeat url('/images/search-result-caret.svg') center right;
+      background: no-repeat image-url('/images/search-result-caret.svg') center right;
       background-size: contain;
     }
   }

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -152,12 +152,12 @@
           height: 20px;
           float: right;
 
-          background-image: url('/images/govuk-icn-numbered-list.png');
+          background-image: image-url('/images/govuk-icn-numbered-list.png');
           background-repeat: no-repeat;
           background-position: left center;
 
           @include govuk-device-pixel-ratio {
-            background-image: url('/images/govuk-icn-numbered-list@2x.png');
+            background-image: image-url('/images/govuk-icn-numbered-list@2x.png');
             background-size: 20px 20px;
           }
         }
@@ -178,12 +178,12 @@
         height: 20px;
         cursor: pointer;
 
-        background-image: url('/images/govuk-icn-close.png');
+        background-image: image-url('/images/govuk-icn-close.png');
         background-repeat: no-repeat;
         background-position: left center;
 
         @include govuk-device-pixel-ratio {
-          background-image: url('/images/govuk-icn-close@2x.png');
+          background-image: image-url('/images/govuk-icn-close@2x.png');
           background-size: 20px 20px;
         }
 


### PR DESCRIPTION
Hello 👋 

This PR fixes asset URLs for sites built for Github pages using the default URL (like the [API catalogue](https://github.com/alphagov/api-catalogue)), in which paths are prefixed with the repo name.

## Changes

- Allow `$govuk-assets-path` to be overriden by implementors
- Use Sprockets URL helpers to ensure image backround URLs in CSS account for Middleman's `http_prefix` setting

## Context

For repo-specific Github pages, the site is deployed with the repo name prefixed in the path, e.g. `https://alphagov.github.io/api-catalogue/`. We'd like to use Middleman's [`http_prefix`](https://rubydoc.info/github/middleman/middleman/Middleman/Application#http_prefix-instance_method) option to account for this path prefix, which will allow us to simplify and automate  our build process.

Our Middleman config looks like this:

```ruby
# Without prefix for 'middleman serve'
set(:govuk_assets_path, "/assets/govuk/assets/")

# Add '/api-catalogue/' for 'middleman build', for Github Pages compatibility
configure :build do
  set(:build_dir, "build/api-catalogue")
  set(:http_prefix, "/api-catalogue/")
  set(:govuk_assets_path, "/api-catalogue/assets/govuk/assets/")
end
```

With this PR all asset URLs correctly include the `/api-catalogue/` prefix, and we can avoid using Middleman's `activate :relative_assets` feature.

## References

- [middleman-sprockets `asset_path` / `image-url` helpers](https://github.com/middleman/middleman-sprockets/blob/5e5197c3e4049845c446dc2b30d0169f2b3c6070/features/middleman_helpers.feature#L3)
- GOV.UK Frontend [using `!default` to allow overrides](https://github.com/alphagov/govuk-frontend/blob/063cd8e2470b62b824c6e50ca66342ac7a95d2d8/src/govuk/settings/_assets.scss#L14)
- Semi-related PR which [fixes search with `http_prefix` configued](https://github.com/alphagov/tech-docs-gem/pull/196)