### PR TITLE
Cache gems + node modules on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+cache:
+  bundler: true
+  npm: true
 before_install:
   - gem update --system
   - gem install bundler


### PR DESCRIPTION
Whilst contributing other PRs I noticed the time to run tests on CI could be improved by using the [Travis dependency cache](https://docs.travis-ci.com/user/caching#caching-directories-bundler-dependencies).

Before the change, recent builds on `master` have taken approx 5m30s-5m50s to complete - including over 3 minutes spent installing gems. With a warm cache this drops to ~2m30s build time, and installing gems takes under 10 seconds.

## Before

<img width="936" alt="build-before" src="https://user-images.githubusercontent.com/4125410/94806199-7c231480-03e5-11eb-8e80-34edfbf718dc.png">

## After

<img width="932" alt="build-after" src="https://user-images.githubusercontent.com/4125410/94806215-7fb69b80-03e5-11eb-8331-76f9516efe65.png">