### PR TITLE
Fix page expiry box link colours (hover and focus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes in the following pull requests:
+
+- [#199: Fix page expiry box link colours (hover and focus) ](https://github.com/alphagov/tech-docs-gem/pull/199)
+
 ## 2.1.0
 
 ### New features

--- a/lib/assets/stylesheets/modules/_page-review.scss
+++ b/lib/assets/stylesheets/modules/_page-review.scss
@@ -13,11 +13,9 @@
 
   a:link,
   a:visited {
-    color: inherit;
-  }
-
-  a:hover {
-    color: $govuk-link-hover-colour;
+    &:not(:focus) {
+      color: inherit;
+    }
   }
 
   a:active {


### PR DESCRIPTION
Adjust page expiry links' styles with the aim of resolving insufficient colour contrast issues on the hover and focus states.

## Issues ⬇️ 
<img width="772" alt="Screenshot 2020-10-16 at 10 22 00" src="https://user-images.githubusercontent.com/7116819/96241044-93433400-0f99-11eb-981e-61551f8c4106.png">
<img width="778" alt="Screenshot 2020-10-16 at 10 22 13" src="https://user-images.githubusercontent.com/7116819/96241046-93dbca80-0f99-11eb-9a90-b1dcfbcbc66a.png">
