### PR TITLE
Bump bundler

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sprockets", "~> 4.0.0"
 
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"
   spec.add_development_dependency "jasmine", "~> 3.5.0"


### PR DESCRIPTION
Travis doesn't have Bundler 2.1.4 and builds are failing.

See https://travis-ci.org/github/alphagov/tech-docs-gem/jobs/737449374