### PR TITLE
Improve table of contents accessibility

### DIFF
--- a/lib/assets/javascripts/_modules/table-of-contents.js
+++ b/lib/assets/javascripts/_modules/table-of-contents.js
@@ -7,23 +7,22 @@
     var $toc
     var $tocList
 
-    var $openLink
-    var $closeLink
+    var $openButton
+    var $closeButton
 
     this.start = function ($element) {
       $toc = $element
       $tocList = $toc.find('.js-toc-list')
-
       // Open link is not inside the module
-      $openLink = $html.find('.js-toc-show')
-      $closeLink = $toc.find('.js-toc-close')
+      $openButton = $html.find('.js-toc-show')
+      $closeButton = $toc.find('.js-toc-close')
 
       fixRubberBandingInIOS()
       updateAriaAttributes()
 
       // Need delegated handler for show link as sticky polyfill recreates element
-      $openLink.on('click.toc', preventingScrolling(openNavigation))
-      $closeLink.on('click.toc', preventingScrolling(closeNavigation))
+      $openButton.on('click.toc', preventingScrolling(openNavigation))
+      $closeButton.on('click.toc', preventingScrolling(closeNavigation))
       $tocList.on('click.toc', 'a', closeNavigation)
 
       // Allow aria hidden to be updated when resizing from mobile to desktop or
@@ -65,8 +64,7 @@
 
       toggleBackgroundVisiblity(false)
       updateAriaAttributes()
-
-      focusFirstLinkInToc()
+      $toc.focus()
     }
 
     function closeNavigation () {
@@ -76,10 +74,6 @@
       updateAriaAttributes()
     }
 
-    function focusFirstLinkInToc () {
-      $('a', $tocList).first().focus()
-    }
-
     function toggleBackgroundVisiblity (visibility) {
       $('.toc-open-disabled').attr('aria-hidden', visibility ? '' : 'true')
     }
@@ -87,7 +81,7 @@
     function updateAriaAttributes () {
       var tocIsVisible = $toc.is(':visible')
 
-      $($openLink).add($closeLink)
+      $($openButton).add($closeButton)
         .attr('aria-expanded', tocIsVisible ? 'true' : 'false')
 
       $toc.attr('aria-hidden', tocIsVisible ? 'false' : 'true')

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -127,7 +127,7 @@
           display: block;
           position: relative;
           z-index: 10;
-
+          width: 100%;
           padding: govuk-spacing(3) govuk-spacing(3) 10px;
 
           background: govuk-colour("light-grey");
@@ -135,10 +135,12 @@
             background: transparentize(govuk-colour("light-grey"), 0.05);
             backdrop-filter: blur(2px);
           }
+          border: 0;
           border-bottom: 1px solid govuk-colour("mid-grey");
           box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
           color:  $govuk-text-colour;
           text-decoration: none;
+          text-align: left;
 
           &:focus {
             @include govuk-focused-text;
@@ -170,7 +172,7 @@
         position: sticky;
         right: 0;
         top: 0;
-
+        border: 0;
         float: right;
         width: 20px;
         height: 20px;

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -34,18 +34,18 @@
 
       <% if content_for? :sidebar %>
         <div id="toc-heading" class="toc-show fixedsticky">
-          <a href="#toc" class="toc-show__label js-toc-show" aria-controls="toc">
+          <button type="button" class="toc-show__label js-toc-show" aria-controls="toc">
             Table of contents <span class="toc-show__icon"></span>
-          </a>
+          </button>
         </div>
       <% end %>
 
       <div class="app-pane__body"<%= " data-module=\"#{yield_content(:toc_module)}\"" if content_for? :toc_module %>>
         <% if content_for? :sidebar %>
           <div class="app-pane__toc">
-            <div class="toc" data-module="table-of-contents">
+            <div class="toc" data-module="table-of-contents" tabindex="-1" aria-label="Table of contents">
               <%= partial "layouts/search" %>
-              <a href="#" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></a>
+              <button type="button" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></button>
               <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading"<%= " data-module=\"collapsible-navigation\"" if config[:tech_docs][:collapsible_nav] %>>
                 <%= yield_content :sidebar %>
               </nav>


### PR DESCRIPTION
The table of contents fails [WCAG 2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html). 
When the table of contents is expanded, a search field and a list of (sometimes) collapsible options appear. Focus is automatically set to the first link on the list, which means that screen reader users might miss both the search box and the "hide table of contents" button.
The changes introduced in this PR ensure that focus is not set on the first nav option, but on the entire region. This way when the user navigates forward, they are able to encounter the search box and the "close" button.

Additionally, adjust the markup for the open/close TOC buttons to use the `<button>` element instead of an anchor tag. The reason is that these elements both look and behave as buttons, not as links. This should aid assistive tech users in navigating this functionality (for ex using voice control)