### PR TITLE
Remove tdt docs content from readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,19 @@
 This repo contains the Ruby gem that distributes the [Tech Docs Template][tdt-template]. The Tech Docs Template is a [middleman template][mmt] that
 you can use to build technical documentation using a GOV.UK style.
 
-👉 Find out more about the template and its features from the [Tech Docs Template documentation][tdt-docs].
-
-## Usage
-
-👉 Find out how to [generate a new website with the Tech Docs Template][tdt-readme].
+👉 To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation][tdt-docs].
 
 ## Contributing
 
 Everybody who uses this project is encouraged to contribute.
 
-👉 [See CONTRIBUTING.md](CONTRIBUTING.md) for guidance on making changes.
+👉 See the[CONTRIBUTING.md file](CONTRIBUTING.md) for guidance on contributing to this project.
 
 ## GOV.UK frontend
 
 This gem uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), part of the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-We use `npm` to download the govuk-frontend package. To update to a new version, change the version in [package.json](blob/master/package.json) and run `npm update`.
+We use `npm` to download the govuk-frontend package. To update to a new version, change the version in the [package.json file](blob/master/package.json) and run `npm update`.
 
 ## Developing locally
 
@@ -30,7 +26,7 @@ There are 2 ways to develop with this gem. You can see your changes on either:
 
 ### Use your own Tech Docs Template website
 
-If you want to see how your changes to the gem affect your website, you have to point your site's Gemfile to your local checkout:
+To see how your changes to the gem affect your website, point your website's Gemfile to your local checkout:
 
 ```rb
 gem 'govuk_tech_docs', path: '../tech-docs-gem'
@@ -44,6 +40,8 @@ bundle exec middleman server
 
 See your website on `http://localhost:4567` in your browser.
 
+For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+
 ### Use the example in this repo
 
 To start the example in this repo, run:
@@ -56,14 +54,16 @@ bundle exec middleman server
 
 See your website on `http://localhost:4567` in your browser.
 
+For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+
 ## Tests
 
-The repository contains automated JavaScript tests that use [Jasmine][jas] test framework.
+This repository contains automated JavaScript tests that use the [Jasmine test framework][jas].
 
 To run the tests and see the results in your browser:
 
-1. Run `bundle exec rake jasmine`
-2. Go to `http://localhost:8888` in your browser
+1. Run `bundle exec rake jasmine`.
+2. Go to `http://localhost:8888` in your browser.
 
 To run the tests and see the results in your terminal, run:
 
@@ -73,14 +73,15 @@ bundle exec rake jasmine:ci
 
 ## Releasing new versions
 
-To release a new version, create a new Pull Request that updates [version.rb](lib/govuk_tech_docs/version.rb) and [CHANGELOG.md](CHANGELOG.md). Don't mix this in with other changes - this makes it easier to find out what was released when. See [this PR to release a new version as an example](https://github.com/alphagov/tech-docs-gem/pull/15).
+To release a new version, create a new pull request (PR) that updates [version.rb](lib/govuk_tech_docs/version.rb) and [CHANGELOG.md](CHANGELOG.md).
+
+Do not include other changes in this pull request, as this makes it easier to find out what was released when. See this [PR for releasing a new version](https://github.com/alphagov/tech-docs-gem/pull/15) as an example.
 
 Travis will automatically release a [new version to Rubygems.org](https://rubygems.org/gems/govuk_tech_docs).
 
 ## Licence
 
-Unless stated otherwise, the codebase is released under [the MIT License][mit].
-This covers both the codebase and any sample code in the documentation.
+Unless stated otherwise, the codebase is released under [the MIT License][mit]. This covers both the codebase and any sample code in the documentation.
 
 The documentation is [© Crown copyright][copyright] and available under the terms of the [Open Government 3.0][ogl] licence.
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,7 @@ To see how your changes to the gem affect your website, point your website's Gem
 gem 'govuk_tech_docs', path: '../tech-docs-gem'
 ```
 
-To view your changes locally run:
-
-```sh
-bundle exec middleman server
-```
-
-See your website on `http://localhost:4567` in your browser.
-
-For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+To preview your documentation changes locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
 ### Use the example in this repo
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This repo contains the Ruby gem that distributes the [Tech Docs Template][tdt-template]. The Tech Docs Template is a [middleman template][mmt] that
 you can use to build technical documentation using a GOV.UK style.
 
-👉 To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation][tdt-docs].
+To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation][tdt-docs].
 
 ## Contributing
 
 Everybody who uses this project is encouraged to contribute.
 
-👉 See the[CONTRIBUTING.md file](CONTRIBUTING.md) for guidance on contributing to this project.
+You can find out more about contributing to this project from the[CONTRIBUTING.md file](CONTRIBUTING.md).
 
 ## GOV.UK frontend
 
@@ -32,7 +32,7 @@ To see how your changes to the gem affect your website, point your website's Gem
 gem 'govuk_tech_docs', path: '../tech-docs-gem'
 ```
 
-To preview your documentation changes locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+To preview your documentation changes locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
 ### Use the example in this repo
 
@@ -52,7 +52,7 @@ For more information on previewing your documentation locally, see the [Tech Doc
 
 This repository contains automated JavaScript tests that use the [Jasmine test framework][jas].
 
-To run the tests and see the results in your browser:
+You can run these tests and see the results in your browser.
 
 1. Run `bundle exec rake jasmine`.
 2. Go to `http://localhost:8888` in your browser.
@@ -67,7 +67,7 @@ bundle exec rake jasmine:ci
 
 To release a new version, create a new pull request (PR) that updates [version.rb](lib/govuk_tech_docs/version.rb) and [CHANGELOG.md](CHANGELOG.md).
 
-Do not include other changes in this pull request, as this makes it easier to find out what was released when. See this [PR for releasing a new version](https://github.com/alphagov/tech-docs-gem/pull/15) as an example.
+Do not include other changes in your pull request, as this makes it easier to find out what was released when. See an example of a [PR for releasing a new version](https://github.com/alphagov/tech-docs-gem/pull/15).
 
 Travis will automatically release a [new version to Rubygems.org](https://rubygems.org/gems/govuk_tech_docs).
 


### PR DESCRIPTION
The [tech-docs-template repo README](https://github.com/alphagov/tech-docs-template) no longer has content that duplicates [the TDT documentation](https://tdt-documentation.london.cloudapps.digital/).

This PR does the same for the tech-docs-gem repo.

Trello card: https://trello.com/c/m4JOepVJ/153-de-duplicate-tech-docs-repo-readmes