### PR TITLE
Stop linking images to new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#210: Fix issue with WCAG 2.1 success criterion 1.3.1 (Info and Relationships)](https://github.com/alphagov/tech-docs-gem/pull/210)
+
 ### Ruby version bump
 
 We've updated the Ruby version supported:

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -20,7 +20,7 @@ module GovukTechDocs
     end
 
     def image(link, *args)
-      %(<a href="#{link}" target="_blank" rel="noopener noreferrer">#{super}</a>)
+      %(<a href="#{link}" rel="noopener noreferrer">#{super}</a>)
     end
 
     def table(header, body)


### PR DESCRIPTION
This fixes one of our [accessibility issues][1]. Specifically, it will
prevent images to link to new tabs without telling the user, which fails
[WCAG 2.1 success criterion 2.4.4 Link Purpose (in context)][2].

[1]: https://docs.google.com/spreadsheets/d/1s53eGMBj2hdTVLRitwi673R-_uERWh0kOxOp9QsOVg0
[2]: https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html

Trello card: https://trello.com/c/vv0OR35g/630-march-update-tech-docs-template