### PR TITLE
Add missing 2.1.1 entry in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## Unreleased
 
-### Ruby version bump
+- [#205: Improve table of contents accessibility](https://github.com/alphagov/tech-docs-gem/pull/205)
+- [#206 Remove tdt docs content from readme file](https://github.com/alphagov/tech-docs-gem/pull/206)
 
-We've updated the Ruby version supported:
-
-- [#201: Bump ruby to 2.7.2](https://github.com/alphagov/tech-docs-gem/pull/201)
+## 2.1.1
 
 ### Fixes
 
 We’ve made fixes in the following pull requests:
 
 - [#199: Fix page expiry box link colours (hover and focus) ](https://github.com/alphagov/tech-docs-gem/pull/199)
+### Ruby version bump
+
+We've updated the Ruby version supported:
+
+- [#201: Bump ruby to 2.7.2](https://github.com/alphagov/tech-docs-gem/pull/201)
 
 ## 2.1.0
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "2.1.1".freeze
+  VERSION = "2.1.2".freeze
 end


### PR DESCRIPTION
I messed up the CHANGELOG in bumping the version to 2.1.1

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️