### PR TITLE
Add tabindex and focus states to code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#210: Fix issue with WCAG 2.1 success criterion 1.3.1 (Info and Relationships)](https://github.com/alphagov/tech-docs-gem/pull/210)
 - [#209: Some search and keyboard navigation updates](https://github.com/alphagov/tech-docs-gem/pull/209)
 - [#214: Implement row level table headings to allow accessible tables with row headings](https://github.com/alphagov/tech-docs-gem/pull/214)
+- [#215: Add tabindex and focus states to code blocks](https://github.com/alphagov/tech-docs-gem/pull/215)
 
 ### Ruby version bump
 

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -123,6 +123,12 @@
     overflow: auto;
     position: relative;
     border: 1px solid $code-02;
+
+    &:focus {
+      padding: 13px;
+      border: $govuk-focus-width solid $govuk-focus-text-colour;
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+    }
   }
 
   pre code {

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -118,14 +118,17 @@
   }
 
   pre {
+    $padding: 15px;
+    $border-width: 1px;
+
     background: $code-00;
-    padding: 15px;
+    padding: $padding;
     overflow: auto;
     position: relative;
-    border: 1px solid $code-02;
+    border: $border-width solid $code-02;
 
     &:focus {
-      padding: 13px;
+      padding: $padding - ($govuk-focus-width - $border-width);
       border: $govuk-focus-width solid $govuk-focus-text-colour;
       outline: $govuk-focus-width solid $govuk-focus-colour;
     }

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -74,5 +74,23 @@ module GovukTechDocs
 
       tr.to_html
     end
+
+    def block_code(text, lang)
+      if defined?(super)
+        # Post-processing the block_code HTML to implement tabbable code blocks.
+        #
+        # Middleman monkey patches the Middleman::Renderers::MiddlemanRedcarpetHTML
+        # to include Middleman::Syntax::RedcarpetCodeRenderer. This defines its own
+        # version of `block_code(text, lang)` which we can call with `super`.
+
+        highlighted_html = super
+        highlighted_html.sub("<pre ", '<pre tabindex="0" ')
+      else
+        # If syntax highlighting with redcarpet isn't enabled, super will not
+        # be `defined?`, so we can jump straight to rendering HTML ourselves.
+
+        "<pre tabindex=\"0\"><code class=\"#{lang}\">#{text}</code></pre>"
+      end
+    end
   end
 end

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -83,13 +83,25 @@ module GovukTechDocs
         # to include Middleman::Syntax::RedcarpetCodeRenderer. This defines its own
         # version of `block_code(text, lang)` which we can call with `super`.
 
-        highlighted_html = super
-        highlighted_html.sub("<pre ", '<pre tabindex="0" ')
+        fragment = Nokogiri::HTML::DocumentFragment.parse(super)
+        fragment.traverse do |element|
+          if element.name == "pre" && element["tabindex"].nil?
+            element["tabindex"] = "0"
+          end
+        end
+        fragment.to_html
       else
         # If syntax highlighting with redcarpet isn't enabled, super will not
         # be `defined?`, so we can jump straight to rendering HTML ourselves.
 
-        "<pre tabindex=\"0\"><code class=\"#{lang}\">#{text}</code></pre>"
+        fragment = Nokogiri::HTML::DocumentFragment.parse("")
+        pre = Nokogiri::XML::Node.new "pre", fragment
+        pre["tabindex"] = "0"
+        code = Nokogiri::XML::Node.new "code", fragment
+        code["class"] = lang
+        code.content = text
+        pre.add_child code
+        pre.to_html
       end
     end
   end

--- a/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
+++ b/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
@@ -1,3 +1,5 @@
+require "middleman-syntax/extension"
+
 RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
   let(:app) { double("app") }
   let(:context) { double("context") }
@@ -39,6 +41,72 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
       expect(output).to include("<td>E</td>")
       expect(output).to include("<td>F</td>")
       expect(output).to include("<td>H</td>")
+    end
+  end
+end
+
+RSpec.describe "code blocks" do
+  let(:app) { double("app") }
+  let(:context) { double("context") }
+
+  before :each do
+    allow(context).to receive(:app) { app }
+    allow(app).to receive(:api)
+  end
+
+  describe "without syntax highlighting" do
+    let(:processor) {
+      Redcarpet::Markdown.new(GovukTechDocs::TechDocsHTMLRenderer.new(context: context), fenced_code_blocks: true)
+    }
+
+    describe "#render" do
+      it "sets tab index to 0" do
+        output = processor.render <<~MARKDOWN
+          Hello world:
+
+          ```ruby
+          def hello_world
+            puts "hello world"
+          end
+          ```
+        MARKDOWN
+
+        expect(output).to include('<pre tabindex="0">')
+        expect(output).to include("def hello_world")
+        expect(output).to include('puts "hello world"')
+        expect(output).to include("end")
+      end
+    end
+  end
+
+  describe "with syntax highlighting" do
+    let(:processor) {
+      renderer_class = GovukTechDocs::TechDocsHTMLRenderer.clone.tap do |c|
+        c.send :include, Middleman::Syntax::RedcarpetCodeRenderer
+      end
+
+      Redcarpet::Markdown.new(renderer_class.new(context: context), fenced_code_blocks: true)
+    }
+
+    describe "#render" do
+      it "sets tab index to 0" do
+        output = processor.render <<~MARKDOWN
+          Hello world:
+
+          ```ruby
+          def hello_world
+            puts "hello world"
+          end
+          ```
+        MARKDOWN
+
+        expect(output).to include('<pre tabindex="0" class=" ruby">')
+        expect(output).to include("def</span>")
+        expect(output).to include("hello_world</span>")
+        expect(output).to include("puts</span>")
+        expect(output).to include('"hello world"</span>')
+        expect(output).to include("end</span>")
+      end
     end
   end
 end

--- a/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
+++ b/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
 
       describe "#render a code block" do
         it "sets tab index to 0" do
-          expect(output).to include('<pre tabindex="0" class=" ruby">')
+          expect(output).to include('<pre class=" ruby" tabindex="0">')
         end
 
         it "renders the code with syntax highlighting" do

--- a/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
+++ b/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
@@ -4,108 +4,89 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
   let(:app) { double("app") }
   let(:context) { double("context") }
   let(:processor) {
-    allow(context).to receive(:app) { app }
-    allow(app).to receive(:api)
-    Redcarpet::Markdown.new(described_class.new(context: context), tables: true)
+    Redcarpet::Markdown.new(described_class.new(context: context), tables: true, fenced_code_blocks: true)
   }
-
-  describe "#render a table" do
-    markdown_table = <<~MARKDOWN
-     |  A   | B |
-     |------|---|
-     |# C   | D |
-     |  E   | F |
-     |# *G* | H |
-    MARKDOWN
-
-    it "treats cells in the heading row as headings" do
-      output = processor.render markdown_table
-
-      expect(output).to include("<th>A</th>")
-      expect(output).to include("<th>B</th>")
-    end
-
-    it "treats cells starting with # as row headings" do
-      output = processor.render markdown_table
-      expect(output).to include('<th scope="row">C</th>')
-    end
-
-    it "treats cells starting with # with more complex markup as row headings" do
-      output = processor.render markdown_table
-      expect(output).to match(/<th scope="row"><em>G<\/em>\s*<\/th>/)
-    end
-
-    it "treats other cells as ordinary cells" do
-      output = processor.render markdown_table
-      expect(output).to include("<td>D</td>")
-      expect(output).to include("<td>E</td>")
-      expect(output).to include("<td>F</td>")
-      expect(output).to include("<td>H</td>")
-    end
-  end
-end
-
-RSpec.describe "code blocks" do
-  let(:app) { double("app") }
-  let(:context) { double("context") }
 
   before :each do
     allow(context).to receive(:app) { app }
     allow(app).to receive(:api)
   end
 
-  describe "without syntax highlighting" do
-    let(:processor) {
-      Redcarpet::Markdown.new(GovukTechDocs::TechDocsHTMLRenderer.new(context: context), fenced_code_blocks: true)
+  describe "#render a table" do
+    let(:output) {
+      processor.render <<~MARKDOWN
+        |  A   | B |
+        |------|---|
+        |# C   | D |
+        |  E   | F |
+        |# *G* | H |
+      MARKDOWN
     }
 
-    describe "#render" do
-      it "sets tab index to 0" do
-        output = processor.render <<~MARKDOWN
-          Hello world:
+    it "treats cells in the heading row as headings" do
+      expect(output).to include("<th>A</th>")
+      expect(output).to include("<th>B</th>")
+    end
 
-          ```ruby
-          def hello_world
-            puts "hello world"
-          end
-          ```
-        MARKDOWN
+    it "treats cells starting with # as row headings" do
+      expect(output).to include('<th scope="row">C</th>')
+    end
 
-        expect(output).to include('<pre tabindex="0">')
-        expect(output).to include("def hello_world")
-        expect(output).to include('puts "hello world"')
-        expect(output).to include("end")
-      end
+    it "treats cells starting with # with more complex markup as row headings" do
+      expect(output).to match(/<th scope="row"><em>G<\/em>\s*<\/th>/)
+    end
+
+    it "treats other cells as ordinary cells" do
+      expect(output).to include("<td>D</td>")
+      expect(output).to include("<td>E</td>")
+      expect(output).to include("<td>F</td>")
+      expect(output).to include("<td>H</td>")
     end
   end
 
-  describe "with syntax highlighting" do
-    let(:processor) {
-      renderer_class = GovukTechDocs::TechDocsHTMLRenderer.clone.tap do |c|
-        c.send :include, Middleman::Syntax::RedcarpetCodeRenderer
-      end
+  describe "#render a code block" do
+    let(:output) {
+      processor.render <<~MARKDOWN
+        Hello world:
 
-      Redcarpet::Markdown.new(renderer_class.new(context: context), fenced_code_blocks: true)
+        ```ruby
+        def hello_world
+          puts "hello world"
+        end
+        ```
+      MARKDOWN
     }
 
-    describe "#render" do
-      it "sets tab index to 0" do
-        output = processor.render <<~MARKDOWN
-          Hello world:
+    it "sets tab index to 0" do
+      expect(output).to include('<pre tabindex="0">')
+    end
 
-          ```ruby
-          def hello_world
-            puts "hello world"
-          end
-          ```
-        MARKDOWN
+    it "renders the code without syntax highlighting" do
+      expect(output).to include("def hello_world")
+      expect(output).to include('puts "hello world"')
+      expect(output).to include("end")
+    end
 
-        expect(output).to include('<pre tabindex="0" class=" ruby">')
-        expect(output).to include("def</span>")
-        expect(output).to include("hello_world</span>")
-        expect(output).to include("puts</span>")
-        expect(output).to include('"hello world"</span>')
-        expect(output).to include("end</span>")
+    describe "with syntax highlighting" do
+      let(:processor) {
+        renderer_class = described_class.clone.tap do |c|
+          c.send :include, Middleman::Syntax::RedcarpetCodeRenderer
+        end
+        Redcarpet::Markdown.new(renderer_class.new(context: context), tables: true, fenced_code_blocks: true)
+      }
+
+      describe "#render a code block" do
+        it "sets tab index to 0" do
+          expect(output).to include('<pre tabindex="0" class=" ruby">')
+        end
+
+        it "renders the code with syntax highlighting" do
+          expect(output).to include("def</span>")
+          expect(output).to include("hello_world</span>")
+          expect(output).to include("puts</span>")
+          expect(output).to include('"hello world"</span>')
+          expect(output).to include("end</span>")
+        end
       end
     end
   end

--- a/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
+++ b/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
@@ -57,36 +57,41 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
       MARKDOWN
     }
 
-    it "sets tab index to 0" do
-      expect(output).to include('<pre tabindex="0">')
+    context "without syntax highlighting" do
+      let(:processor) {
+        Redcarpet::Markdown.new(described_class.new(context: context), fenced_code_blocks: true)
+      }
+
+      it "sets tab index to 0" do
+        expect(output).to include('<pre tabindex="0">')
+      end
+
+      it "renders the code without syntax highlighting" do
+        expect(output).to include("def hello_world")
+        expect(output).to include('puts "hello world"')
+        expect(output).to include("end")
+      end
     end
 
-    it "renders the code without syntax highlighting" do
-      expect(output).to include("def hello_world")
-      expect(output).to include('puts "hello world"')
-      expect(output).to include("end")
-    end
 
-    describe "with syntax highlighting" do
+    context "with syntax highlighting" do
       let(:processor) {
         renderer_class = described_class.clone.tap do |c|
           c.send :include, Middleman::Syntax::RedcarpetCodeRenderer
         end
-        Redcarpet::Markdown.new(renderer_class.new(context: context), tables: true, fenced_code_blocks: true)
+        Redcarpet::Markdown.new(renderer_class.new(context: context), fenced_code_blocks: true)
       }
 
-      describe "#render a code block" do
-        it "sets tab index to 0" do
-          expect(output).to include('<pre class=" ruby" tabindex="0">')
-        end
+      it "sets tab index to 0" do
+        expect(output).to include('<pre class=" ruby" tabindex="0">')
+      end
 
-        it "renders the code with syntax highlighting" do
-          expect(output).to include("def</span>")
-          expect(output).to include("hello_world</span>")
-          expect(output).to include("puts</span>")
-          expect(output).to include('"hello world"</span>')
-          expect(output).to include("end</span>")
-        end
+      it "renders the code with syntax highlighting" do
+        expect(output).to include("def</span>")
+        expect(output).to include("hello_world</span>")
+        expect(output).to include("puts</span>")
+        expect(output).to include('"hello world"</span>')
+        expect(output).to include("end</span>")
       end
     end
   end


### PR DESCRIPTION
This is required for accessibility reasons. Because some code blocks have scrollbars they need to be focusable using a keyboard.

I've copied the styles from the design system's documentation (see the code blocks in the HTML / Nunjucks tabs here: https://design-system.service.gov.uk/components/button/)

The implementation is simple when syntax highlighting is not enabled, because we can simply implement `block_code` to surround the code with the markup we want.

When syntax highlighting is enabled it's a bit more complicated.  Middleman already `include`s its own implementation of `block_code`, which renders the source code highlighted with spans. This method doesn't look like it would be easy to customise, so instead I've resorted to post-processing the HTML (i.e. replacing the attributes on the `<pre>` tag using a regex).

Testing this was a bit tricky, because you need to monkey patch the class to include the `block_code` method. I had to clone the class and patch the clone to do avoid affecting other tests.

Example from a locally running version of the paas tech docs:

![image](https://user-images.githubusercontent.com/1696784/110805148-bc31d180-8278-11eb-88f0-601bca75cf82.png)


-----

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️