### PR TITLE
Remove unnecessary explicit dependencies: sprockets, activesupport, sass and pry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased
+## 2.2.1
 
-- [Pull request: #125: Fix API docs showing required properties as optional](https://github.com/alphagov/tech-docs-gem/pull/125)
+- [#218: Remove unnecessary explicit dependencies: sprockets, activesupport, sass and pry](https://github.com/alphagov/tech-docs-gem/pull/218)
+- [#125: Fix API docs showing required properties as optional](https://github.com/alphagov/tech-docs-gem/pull/125)
 
 ## 2.2.0
 

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
   spec.add_dependency "chronic", "~> 0.10.2"
   spec.add_dependency "middleman", "~> 4.0"
   spec.add_dependency "middleman-autoprefixer", "~> 2.10.0"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-syntax", "~> 3.2.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
-  spec.add_dependency "pry"
   spec.add_dependency "redcarpet", "~> 3.5.0"
 
   spec.add_development_dependency "bundler", "~> 2.2.0"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
   spec.add_dependency "redcarpet", "~> 3.5.0"
 
-  spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"
   spec.add_development_dependency "jasmine", "~> 3.5.0"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
   spec.add_dependency "pry"
   spec.add_dependency "redcarpet", "~> 3.5.0"
-  spec.add_dependency "sass"
 
   spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "byebug"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
   spec.add_dependency "redcarpet", "~> 3.5.0"
   spec.add_dependency "sass"
-  spec.add_dependency "sprockets", "~> 4.0.0"
 
   spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "byebug"

--- a/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_extension.rb
@@ -1,7 +1,6 @@
 require "erb"
 require "openapi3_parser"
 require "uri"
-require "pry"
 require "govuk_tech_docs/api_reference/api_reference_renderer"
 
 module GovukTechDocs

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "2.2.0".freeze
+  VERSION = "2.2.1".freeze
 end


### PR DESCRIPTION
With the exception of pry, none of these dependencies are explicitly referenced in the code (activesupport and sprockets are implicit though). This removes an unnecessary constraint on sprockets 4, as [middleman-sprockets depends on 3 and up](https://github.com/middleman/middleman-sprockets/blob/5e5197c3e4049845c446dc2b30d0169f2b3c6070/middleman-sprockets.gemspec#L20) which causes problems for [apps that integrate with govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/9c8369c82e199a59a1bf8a629d6403fcdf091e9f/govuk_publishing_components.gemspec#L24).

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️