### PR TITLE
ISSUE 220 - Remove unused CSS 'govuk-button' class from the 'search' submit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+
+- [#223: Remove unnecessary CSS class on the search submit button](https://github.com/alphagov/tech-docs-gem/pull/223)
+
 ## 2.2.1
 
 - [#218: Remove unnecessary explicit dependencies: sprockets, activesupport, sass and pry](https://github.com/alphagov/tech-docs-gem/pull/218)

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -11,7 +11,7 @@
       class="govuk-input govuk-!-margin-bottom-0 search__input"
       aria-controls="search-results"
       placeholder="Search">
-    <button type="submit" class="govuk-button search__button">Search</button>
+    <button type="submit" class="search__button">Search</button>
   </form>
   <div id="search-results" class="search-results" aria-hidden="true" role="dialog" aria-labelledby="search-results-title">
     <div class="search-results__inner">


### PR DESCRIPTION
- The 'search' submit button had the un-necessary CSS class 'govuk-button'.
- It a someone uses the gem and they are importing the Design System 'govuk-button' CSS stylesheet,
  then it breaks the styling on the button.

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️