### PR TITLE
ISSUE 221 - Tabbing on search results in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 2.2.2
+## Unreleased
 
 - [#223: Remove unnecessary CSS class on the search submit button](https://github.com/alphagov/tech-docs-gem/pull/223)
+- [#224: Accessibility fix: Hide the 'table of contents close' button when search results are open](https://github.com/alphagov/tech-docs-gem/pull/224)
 
 ## 2.2.1
 

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -57,6 +57,10 @@ html.has-search-results-open {
   .app-pane__content {
     overflow: hidden;
   }
+  
+  .toc__close{
+    display: none;
+  }
 }
 .search-results {
   display: none;


### PR DESCRIPTION
- In mobile view, when you tab through the search results and tab past
  the last result:
  - The focus appears lost as it  goes to a 'close table of contents' button that
    is not in view.
- Update the SASS to hide the button when the search results are open.

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️