### PR TITLE
WIP: Add cookie banner

### DIFF
--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -52,3 +52,12 @@ api_path: source/pets.yml
 # Optional global settings for the page review process
 owner_slack_workspace: gds
 default_owner_slack: '#2nd-line'
+
+cookie_banner:
+  enable: true
+  cookie_types: ['essential','analytics', 'additional']
+  cookie_message_text: |
+    This is my custom text
+    This adds a line break.
+
+    This adds a new paragraph.

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -7,6 +7,8 @@ $govuk-new-link-styles: true;
 @import "govuk/core/all";
 @import "govuk/objects/all";
 
+@import "govuk/components/button/index";
+@import "govuk/components/cookie-banner/index";
 @import "govuk/components/footer/index";
 @import "govuk/components/header/index";
 @import "govuk/components/inset-text/index";

--- a/lib/source/layouts/_cookie_banner.erb
+++ b/lib/source/layouts/_cookie_banner.erb
@@ -1,0 +1,90 @@
+<%
+  is_enabled ||= config.tech_docs.dig(:cookie_banner, :enable)
+
+  essential_cookies = config.tech_docs.dig(:cookie_banner, :cookie_types) ? config[:tech_docs][:cookie_banner][:cookie_types].include?('essential') : false
+  analytics_cookies = config.tech_docs.dig(:cookie_banner, :cookie_types) ? config[:tech_docs][:cookie_banner][:cookie_types].include?('analytics') : false
+  additional_cookies = config.tech_docs.dig(:cookie_banner, :cookie_types) ? config[:tech_docs][:cookie_banner][:cookie_types].include?('additional') : false
+
+  custom_cookie_message_text = config.tech_docs.dig(:cookie_banner, :cookie_message_text)
+
+  cookie_page_path = config.tech_docs.dig(:cookie_banner, :cookie_page_path) ?
+    config[:tech_docs][:cookie_banner][:cookie_page_path] : '/cookies'
+
+  nonessential_cookie_type_text = additional_cookies ? 'additional' : 'analytics'
+%>
+
+<% cookie_message_text = capture do %>
+  <% if essential_cookies %>
+    <p>We use some essential cookies to make this service work.</p>
+  <% end %>
+  <% if additional_cookies %>
+    <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+  <% elsif analytics_cookies %>
+    <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+  <% end %>
+<% end %>
+
+<% if is_enabled %>
+<div class="govuk-cookie-banner " role="region" aria-label="Cookies on <%= config[:tech_docs][:service_name] %>">
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= config[:tech_docs][:service_name] %></h2>
+        <div class="govuk-cookie-banner__content">
+          <% if custom_cookie_message_text || cookie_message_text %>
+            <%= custom_cookie_message_text ? simple_format(custom_cookie_message_text) : cookie_message_text %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <% if analytics_cookies || additional_cookies %>
+        <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button" data-accept-cookies="true">
+          Accept <%= nonessential_cookie_type_text %> cookies
+        </button>
+        <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button" data-accept-cookies="false">
+          Reject <%= nonessential_cookie_type_text %> cookies
+        </button>
+      <% end %>
+      <% if essential_cookies %>
+        <a class="govuk-link" href="<%= cookie_page_path %>">View cookies</a>
+      <% end %>
+      <% if essential_cookies && !(analytics_cookies || additional_cookies) %>
+        <button type="button" class="govuk-button" data-module="govuk-button" data-hide-cookie-banner="true">
+          Hide this message
+        </button>
+      <% end %>
+    </div>
+  </div>
+  <% if analytics_cookies || additional_cookies %>
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-cookie-banner__content">
+            <p>You’ve accepted <%= nonessential_cookie_type_text %> cookies. You can <a href="<%= cookie_page_path %>">change your cookie settings</a> at any time.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button" data-hide-cookie-banner="true">
+          Hide this message
+        </button>
+      </div>
+    </div>
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-cookie-banner__content">
+            <p>You’ve rejected <%= nonessential_cookie_type_text %> cookies. You can <a href="<%= cookie_page_path %>">change your cookie settings</a> at any time.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button" data-hide-cookie-banner="true">
+          Hide this message
+        </button>
+      </div>
+    </div>
+  <% end %>
+</div>
+<% end %>

--- a/lib/source/layouts/_cookie_banner.erb
+++ b/lib/source/layouts/_cookie_banner.erb
@@ -25,8 +25,8 @@
 <% end %>
 
 <% if is_enabled %>
-<div class="govuk-cookie-banner " role="region" aria-label="Cookies on <%= config[:tech_docs][:service_name] %>">
-  <div class="govuk-cookie-banner__message govuk-width-container">
+<div class="govuk-cookie-banner" data-module="cookie-banner" role="region" aria-label="Cookies on <%= config[:tech_docs][:service_name] %>">
+  <div class="govuk-cookie-banner__message js-cookie-message govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= config[:tech_docs][:service_name] %></h2>
@@ -57,7 +57,7 @@
     </div>
   </div>
   <% if analytics_cookies || additional_cookies %>
-    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+    <div class="govuk-cookie-banner__message js-accept-message govuk-width-container" role="alert" hidden>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">
@@ -71,7 +71,7 @@
         </button>
       </div>
     </div>
-    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+    <div class="govuk-cookie-banner__message js-reject-message govuk-width-container" role="alert" hidden>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -24,6 +24,7 @@
 
   <body class="govuk-template__body">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <%= partial 'layouts/cookie_banner' %>
 
     <div class="app-pane">
       <div class="app-pane__header toc-open-disabled">


### PR DESCRIPTION
## What

Implement a configurable cookie banner based on the [GOV.UK Design system cookie banner component](https://design-system.service.gov.uk/components/cookie-banner/)

## How to test

- run locally
- experiment with configuration options ([example config](https://github.com/alphagov/tech-docs-gem/blob/6256243e2bb1ef19a688b344c1b42d85961b16b4/example/config/tech-docs.yml))

To do:
- [x] conditionally show different parts of the cookie banner based on config
- [x] [ document configuration](https://github.com/alphagov/tdt-documentation/pull/153)
- [ ] add tests