### PR TITLE
Fix search 'autocomplete' behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#236: Fix search 'autocomplete' behaviour](https://github.com/alphagov/tech-docs-gem/pull/236)
+
 ## 2.4.2
 
 - [#251 Fix missing `<ul>` in single page navigation](https://github.com/alphagov/tech-docs-gem/pull/251)

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -113,7 +113,7 @@ module GovukTechDocs
           url:     { index: false, store: true },
         }
 
-        search.pipeline_remove = %w[stopWordFilter]
+        search.pipeline_remove = %w[stemmer stopWordFilter]
 
         search.tokenizer_separator = '/[\s\-/]+/'
       end

--- a/spec/javascripts/search-spec.js
+++ b/spec/javascripts/search-spec.js
@@ -75,6 +75,14 @@ describe('Search', function () {
       ]
       expect(searchResults).toEqual(expectedResults)
     })
+
+    it('autocompletes words', function () {
+      module.search('documenta', function (incomplete) {
+        module.search('documentation', function (complete) {
+          expect(incomplete).toEqual(complete)
+        })
+      })
+    })
   })
 
   describe('the processContent method', function () {


### PR DESCRIPTION
Search results will no longer disappear and reappear again as a user is typing a word in.

Fixes #222.

Fix
---

This problem had already been identified in the Design System website, see commit alphagov/govuk-design-system@531d3c3. Thanks @36degrees for flagging that this fix existed.

The fix is to remove the stemmer from the lunr pipeline. This is easily done with the fork of [middleman-search](https://github.com/alphagov/middleman-search) that the tech-docs-gem uses.

This commit also adds a simple test to prevent future changes breaking this functionality.