### PR TITLE
Add headings to TOC

### DIFF
--- a/lib/assets/stylesheets/modules/_collapsible.scss
+++ b/lib/assets/stylesheets/modules/_collapsible.scss
@@ -17,6 +17,11 @@
   margin-right: 30px;
 }
 
+.collapsible__heading h2 {
+  font-size: inherit;
+  margin: 0;
+}
+
 .collapsible__toggle {
   position: absolute;
   top: 0;

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -63,7 +63,7 @@ module GovukTechDocs
             end
 
           if resource.children.any? && resource.url != home_url
-            output += %{<ul><li><a href="#{resource.url}"><span>#{resource.data.title}</span></a>\n}
+            output += %{<ul><li><a href="#{resource.url}"><h2><span>#{resource.data.title}</span></h2></a>\n}
             output += render_page_tree(resource.children, current_page, config, current_page_html)
             output += "</li></ul>"
           else


### PR DESCRIPTION
## What

Add an `h2` heading around TOC links where there is a sub-level `ul` following.

## Why

The recent DAC survey raised this as an accessibility issue. This highlights that there is further content below

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️