### PR TITLE
Move the `aria-expanded` attribute to the correct element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [Bump redcarpet to 3.5.1 to fix CVE-2020-26298](https://github.com/alphagov/tech-docs-gem/pull/226)
+- [#238: Move the aria-expanded attribute to the correct element](https://github.com/alphagov/tech-docs-gem/pull/238)
 
 ## 2.3.0
 

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -34,10 +34,9 @@
           arrayOfIds.push(uniqueId)
           $(this).addClass('collapsible__body')
             .attr('id', uniqueId)
-            .attr('aria-expanded', 'false')
         })
         $heading.addClass('collapsible__heading')
-          .after('<button class="collapsible__toggle" aria-controls="' + arrayOfIds.join(' ') + '"><span class="collapsible__toggle-label">Expand ' + $heading.text() + '</span><span class="collapsible__toggle-icon" aria-hidden="true"></button>')
+          .after('<button class="collapsible__toggle" aria-expanded="false" aria-controls="' + arrayOfIds.join(' ') + '"><span class="collapsible__toggle-label">Expand ' + $heading.text() + '</span><span class="collapsible__toggle-icon" aria-hidden="true"></button>')
         $topLevelItem.on('click', '.collapsible__toggle', function (e) {
           e.preventDefault()
           var $parent = $(this).parent()

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -47,14 +47,15 @@
     }
 
     function toggleHeading ($topLevelItem) {
-      var isOpen = $topLevelItem.hasClass('is-open')
+      var setOpen = !$topLevelItem.hasClass('is-open')
+
       var $heading = $topLevelItem.find('> a')
       var $button = $topLevelItem.find('.collapsible__toggle')
       var $toggleLabel = $topLevelItem.find('.collapsible__toggle-label')
 
-      $topLevelItem.toggleClass('is-open', !isOpen)
-      $button.attr('aria-expanded', isOpen ? 'false' : 'true')
-      $toggleLabel.text(isOpen ? 'Expand ' + $heading.text() : 'Collapse ' + $heading.text())
+      $topLevelItem.toggleClass('is-open', setOpen)
+      $button.attr('aria-expanded', setOpen ? 'true' : 'false')
+      $toggleLabel.text(setOpen ? 'Collapse ' + $heading.text() : 'Expand ' + $heading.text())
     }
 
     function openActiveHeading () {

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -49,11 +49,11 @@
     function toggleHeading ($topLevelItem) {
       var isOpen = $topLevelItem.hasClass('is-open')
       var $heading = $topLevelItem.find('> a')
-      var $body = $topLevelItem.find('.collapsible__body')
+      var $button = $topLevelItem.find('.collapsible__toggle')
       var $toggleLabel = $topLevelItem.find('.collapsible__toggle-label')
 
       $topLevelItem.toggleClass('is-open', !isOpen)
-      $body.attr('aria-expanded', isOpen ? 'false' : 'true')
+      $button.attr('aria-expanded', isOpen ? 'false' : 'true')
       $toggleLabel.text(isOpen ? 'Expand ' + $heading.text() : 'Collapse ' + $heading.text())
     }
 


### PR DESCRIPTION
⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️

## What

* Move the `aria-expanded` attribute onto the toggle button

## Why

From the DAC review:

> There are sections of content with Show/ Hide functionality. Neither the expandable behaviour of the control nor its expanded or collapsed state are programmatically determinable as the aria-expanded attribute has not been utilised (please note, it appears this attribute has been incorrectly associated with the expandable region rather than the trigger).
