### PR TITLE
Update menu html structure so it's one single hierarchical list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [Bump redcarpet to 3.5.1 to fix CVE-2020-26298](https://github.com/alphagov/tech-docs-gem/pull/226)
+- [#240: Update menu html structure so it's one single hierarchical list](https://github.com/alphagov/tech-docs-gem/pull/240)
 
 ## 2.3.0
 

--- a/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
@@ -24,7 +24,7 @@ module GovukTechDocs
         end
 
         if tree.children.any? && level < @max_level
-          output += indentation + "<ul>\n"
+          output += indentation + "<ul>\n" unless level.zero?
 
           tree.children.each do |child|
             output += indentation + INDENTATION_INCREMENT + "<li>\n"
@@ -36,7 +36,7 @@ module GovukTechDocs
             output += indentation + INDENTATION_INCREMENT + "</li>\n"
           end
 
-          output += indentation + "</ul>\n"
+          output += indentation + "</ul>\n" unless level.zero?
         end
 
         output

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -32,7 +32,8 @@ module GovukTechDocs
         # Sort by weight frontmatter
         resources = resources
         .sort_by { |r| [r.data.weight ? 0 : 1, r.data.weight || 0] }
-        output = "";
+        
+        output = "<ul>"
         resources.each do |resource|
           # Skip from page tree if hide_in_navigation:true frontmatter
           next if resource.data.hide_in_navigation
@@ -63,9 +64,9 @@ module GovukTechDocs
             end
 
           if resource.children.any? && resource.url != home_url
-            output += %{<ul><li><a href="#{resource.url}"><span>#{resource.data.title}</span></a>\n}
+            output += %{<li><a href="#{resource.url}"><span>#{resource.data.title}</span></a>\n}
             output += render_page_tree(resource.children, current_page, config, current_page_html)
-            output += "</li></ul>"
+            output += "</li>"
           else
             output +=
               single_page_table_of_contents(
@@ -75,6 +76,8 @@ module GovukTechDocs
               )
           end
         end
+        output += "</ul>"
+
         output
       end
     end

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -32,8 +32,8 @@ module GovukTechDocs
         # Sort by weight frontmatter
         resources = resources
         .sort_by { |r| [r.data.weight ? 0 : 1, r.data.weight || 0] }
-        
-        output = "<ul>"
+
+        output = "<ul>\n"
         resources.each do |resource|
           # Skip from page tree if hide_in_navigation:true frontmatter
           next if resource.data.hide_in_navigation
@@ -66,7 +66,7 @@ module GovukTechDocs
           if resource.children.any? && resource.url != home_url
             output += %{<li><a href="#{resource.url}"><span>#{resource.data.title}</span></a>\n}
             output += render_page_tree(resource.children, current_page, config, current_page_html)
-            output += "</li>"
+            output += "</li>\n"
           else
             output +=
               single_page_table_of_contents(
@@ -76,7 +76,7 @@ module GovukTechDocs
               )
           end
         end
-        output += "</ul>"
+        output += "</ul>\n"
 
         output
       end

--- a/spec/table_of_contents/heading_tree_renderer_spec.rb
+++ b/spec/table_of_contents/heading_tree_renderer_spec.rb
@@ -22,33 +22,29 @@ describe GovukTechDocs::TableOfContents::HeadingTreeRenderer do
     }
 
     let(:expected_html_with_all_headings) {
-      <<~EOF
-      <ul>
-        <li>
-          <a href="#apples"><span>Apples</span></a>
-          <ul>
-            <li>
-              <a href="#apple-recipes"><span>Apple recipes</span></a>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a href="#oranges"><span>Oranges</span></a>
-        </li>
-      </ul>
+      <<-EOF
+  <li>
+    <a href="#apples"><span>Apples</span></a>
+    <ul>
+      <li>
+        <a href="#apple-recipes"><span>Apple recipes</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="#oranges"><span>Oranges</span></a>
+  </li>
       EOF
     }
 
     let(:expected_html_with_max_heading_of_one) {
-      <<~EOF
-      <ul>
-        <li>
-          <a href="#apples"><span>Apples</span></a>
-        </li>
-        <li>
-          <a href="#oranges"><span>Oranges</span></a>
-        </li>
-      </ul>
+      <<-EOF
+  <li>
+    <a href="#apples"><span>Apples</span></a>
+  </li>
+  <li>
+    <a href="#oranges"><span>Oranges</span></a>
+  </li>
       EOF
     }
 

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -18,7 +18,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       }
 
       expected_single_page_table_of_contents = %{
-<ul>
   <li>
     <a href="#fruit"><span>Fruit</span></a>
   </li>
@@ -30,7 +29,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       </li>
     </ul>
   </li>
-</ul>
       }
 
       expect(subject.single_page_table_of_contents(html).strip).to eq(expected_single_page_table_of_contents.strip)
@@ -47,7 +45,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       }
 
       expected_single_page_table_of_contents = %{
-<ul>
   <li>
     <a href="#fruit"><span>Fruit</span></a>
     <ul>
@@ -68,7 +65,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
   <li>
     <a href="#bread"><span>Bread</span></a>
   </li>
-</ul>
       }
 
       expect(subject.single_page_table_of_contents(html).strip).to eq(expected_single_page_table_of_contents.strip)
@@ -148,7 +144,8 @@ describe GovukTechDocs::TableOfContents::Helpers do
       }
 
       expected_multi_page_table_of_contents = %{
-<ul><li><a href="/index.html"><span>Index</span></a>
+<ul>
+<li><a href="/index.html"><span>Index</span></a>
 <ul>
   <li>
     <a href="/a.html#heading-one"><span>Heading one</span></a>
@@ -158,8 +155,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       </li>
     </ul>
   </li>
-</ul>
-<ul>
   <li>
     <a href="/b.html#heading-one"><span>Heading one</span></a>
     <ul>
@@ -169,7 +164,8 @@ describe GovukTechDocs::TableOfContents::Helpers do
     </ul>
   </li>
 </ul>
-</li></ul>
+</li>
+</ul>
       }
 
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
@@ -197,7 +193,8 @@ describe GovukTechDocs::TableOfContents::Helpers do
       }
 
       expected_multi_page_table_of_contents = %{
-<ul><li><a href="/prefix/index.html"><span>Index</span></a>
+<ul>
+<li><a href="/prefix/index.html"><span>Index</span></a>
 <ul>
   <li>
     <a href="/prefix/a.html#heading-one"><span>Heading one</span></a>
@@ -207,8 +204,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       </li>
     </ul>
   </li>
-</ul>
-<ul>
   <li>
     <a href="/prefix/b.html#heading-one"><span>Heading one</span></a>
     <ul>
@@ -218,7 +213,8 @@ describe GovukTechDocs::TableOfContents::Helpers do
     </ul>
   </li>
 </ul>
-</li></ul>
+</li>
+</ul>
       }
 
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)


### PR DESCRIPTION
⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️

## What

Updates the navigation to use a single top level `ul` and nested subnav.

## Why 

This is a follow up to https://github.com/alphagov/tech-docs-gem/pull/237 with a better solution.

The previous markup was like this:

```html
<ul>
  <li>
    <a href="">Top level link</a>
  </li>
</ul>

<ul>
  <li>
    <a href="">Top level link</a>
    <ul>
      <li>indented nav</li>
    </ul>
  </li>
</ul>
```

This separates each top level nav item into a separate list, where the nav should be a single component.

New markup is:

```html
<ul>
  <li>
    <a href="">Top level link</a>
  </li>
  <li>
    <a href="">Top level link</a>
    <ul>
      <li>indented nav</li>
    </ul>
  </li>
</ul>
```