### PR TITLE
Make scrollable area keyboard (and voice) focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#242: Make scrollable area keyboard (and voice) focusable](https://github.com/alphagov/tech-docs-gem/pull/242) (thanks [@colinbm](https://github.com/colinbm))
+
 ## 3.2.1
 
 ### Fixes

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -53,7 +53,7 @@
           </div>
         <% end %>
 
-        <div class="app-pane__content toc-open-disabled">
+        <div class="app-pane__content toc-open-disabled" tabindex="0">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
             <%= yield %>
             <%= partial "layouts/page_review" %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -53,7 +53,7 @@
           </div>
         <% end %>
 
-        <div class="app-pane__content toc-open-disabled" tabindex="0">
+        <div class="app-pane__content toc-open-disabled" aria-label="Content" tabindex="0">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
             <%= yield %>
             <%= partial "layouts/page_review" %>


### PR DESCRIPTION
⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️

## What

Add the main content area to the `tabindex`.

## Why

Using keyboard (or voice) control, the only way to scroll this area is to tab to a focusable item (i.e. a link) within the area. This is a workaround and relies on there being a focusable item within the area, which is not guaranteed. Making the area itself focusable means this will always be scrollable with the keyboard.