### PR TITLE
Fix focus state for links containing inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#238: Move the aria-expanded attribute to the correct element](https://github.com/alphagov/tech-docs-gem/pull/238)
 - [#240: Update menu html structure so it's one single hierarchical list](https://github.com/alphagov/tech-docs-gem/pull/240)
 - [#244: Don't change the focus of the page on initial load](https://github.com/alphagov/tech-docs-gem/pull/244)
+- [#243: Fix focus state for links containing inline code](https://github.com/alphagov/tech-docs-gem/pull/243)
 
 ## 2.3.0
 

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -185,7 +185,7 @@
   }
 
   a:focus code {
-    background: inherit;
+    background: transparent;
     color: inherit;
   }
 


### PR DESCRIPTION
Inheriting the background from the link means that the code block ends up with its own yellow background, which then clips the box-shadow used to give the focused link a black underline.

Rather than inherit the yellow background, set the background to transparent. The focused link still has its own yellow background which can be seen ‘through’ the transparent code element.

## Before

![Screenshot 2021-07-09 at 10 08 31](https://user-images.githubusercontent.com/121939/125054021-a94fd200-e09d-11eb-9df9-c8b724a6fbc0.png)

## After

![Screenshot 2021-07-09 at 10 08 09](https://user-images.githubusercontent.com/121939/125054018-a94fd200-e09d-11eb-9c15-22165a6e6df2.png)
