### PR TITLE
Don't change the focus of the page on initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [Bump redcarpet to 3.5.1 to fix CVE-2020-26298](https://github.com/alphagov/tech-docs-gem/pull/226)
+- [244: Don't change the focus of the page on initial load](https://github.com/alphagov/tech-docs-gem/pull/244)
 
 ## 2.3.0
 

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -47,15 +47,15 @@
         fragment = fragmentForFirstElementInView()
       }
 
-      handleChangeInActiveItem(fragment)
+      handleChangeInActiveItem(fragment, true)
     }
 
     function handleScrollEvent () {
       handleChangeInActiveItem(fragmentForFirstElementInView())
     }
 
-    function handleChangeInActiveItem (fragment) {
-      storeCurrentPositionInHistoryApi(fragment)
+    function handleChangeInActiveItem (fragment, skipHistory) {
+      !skipHistory && storeCurrentPositionInHistoryApi(fragment)
       highlightActiveItemInToc(fragment)
     }
 

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -47,15 +47,13 @@
         fragment = fragmentForFirstElementInView()
       }
 
-      handleChangeInActiveItem(fragment, true)
+      highlightActiveItemInToc(fragment)
     }
 
     function handleScrollEvent () {
-      handleChangeInActiveItem(fragmentForFirstElementInView())
-    }
+      var fragment = fragmentForFirstElementInView()
 
-    function handleChangeInActiveItem (fragment, skipHistory) {
-      !skipHistory && storeCurrentPositionInHistoryApi(fragment)
+      storeCurrentPositionInHistoryApi(fragment)
       highlightActiveItemInToc(fragment)
     }
 

--- a/lib/govuk_tech_docs/table_of_contents/heading.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading.rb
@@ -12,8 +12,12 @@ module GovukTechDocs
         @element_name.scan(/h(\d)/) && $1 && Integer($1)
       end
 
-      def href
-        @page_url + "#" + @attributes["id"]
+      def href(level)
+        if @page_url != "" && level == 1
+          @page_url
+        else
+          @page_url + "#" + @attributes["id"]
+        end
       end
 
       def title

--- a/lib/govuk_tech_docs/table_of_contents/heading.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading.rb
@@ -12,8 +12,8 @@ module GovukTechDocs
         @element_name.scan(/h(\d)/) && $1 && Integer($1)
       end
 
-      def href(level)
-        if @page_url != "" && level == 1
+      def href
+        if @page_url != "" && size == 1
           @page_url
         else
           @page_url + "#" + @attributes["id"]

--- a/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
@@ -20,7 +20,7 @@ module GovukTechDocs
         output = ""
 
         if tree.heading
-          output += indentation + %{<a href="#{tree.heading.href(level)}"><span>#{tree.heading.title}</span></a>\n}
+          output += indentation + %{<a href="#{tree.heading.href}"><span>#{tree.heading.title}</span></a>\n}
         end
 
         if tree.children.any? && level < @max_level

--- a/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading_tree_renderer.rb
@@ -20,7 +20,7 @@ module GovukTechDocs
         output = ""
 
         if tree.heading
-          output += indentation + %{<a href="#{tree.heading.href}"><span>#{tree.heading.title}</span></a>\n}
+          output += indentation + %{<a href="#{tree.heading.href(level)}"><span>#{tree.heading.title}</span></a>\n}
         end
 
         if tree.children.any? && level < @max_level

--- a/spec/table_of_contents/heading_spec.rb
+++ b/spec/table_of_contents/heading_spec.rb
@@ -10,10 +10,40 @@ describe GovukTechDocs::TableOfContents::Heading do
   end
 
   describe "#href" do
-    it "returns a fragment href" do
-      heading = described_class.new(element_name: "", text: "", attributes: { "id" => "apple-recipes" })
+    describe "when page is specified" do
+      describe "and level is 1" do
+        it "returns an href with page and without fragment" do
+          heading = described_class.new(element_name: "", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
 
-      expect(heading.href).to eq("#apple-recipes")
+          expect(heading.href(1)).to eq("index.html")
+        end
+      end
+
+      describe "and level is greater than 1" do
+        it "returns an href with page and fragment" do
+          heading = described_class.new(element_name: "", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
+
+          expect(heading.href(2)).to eq("index.html#apple-recipes")
+        end
+      end
+    end
+
+    describe "when page is not specified" do
+      describe "and level is 1" do
+        it "returns a fragment href" do
+          heading = described_class.new(element_name: "", text: "", attributes: { "id" => "apple-recipes" })
+
+          expect(heading.href(1)).to eq("#apple-recipes")
+        end
+      end
+
+      describe "and level is greater than 1" do
+        it "returns a fragment href" do
+          heading = described_class.new(element_name: "", text: "", attributes: { "id" => "apple-recipes" })
+
+          expect(heading.href(2)).to eq("#apple-recipes")
+        end
+      end
     end
   end
 

--- a/spec/table_of_contents/heading_spec.rb
+++ b/spec/table_of_contents/heading_spec.rb
@@ -11,37 +11,37 @@ describe GovukTechDocs::TableOfContents::Heading do
 
   describe "#href" do
     describe "when page is specified" do
-      describe "and level is 1" do
+      describe "and heading is h1" do
         it "returns an href with page and without fragment" do
-          heading = described_class.new(element_name: "", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
+          heading = described_class.new(element_name: "h1", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
 
-          expect(heading.href(1)).to eq("index.html")
+          expect(heading.href).to eq("index.html")
         end
       end
 
-      describe "and level is greater than 1" do
+      describe "and heading is not h1" do
         it "returns an href with page and fragment" do
-          heading = described_class.new(element_name: "", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
+          heading = described_class.new(element_name: "h2", text: "", page_url: "index.html", attributes: { "id" => "apple-recipes" })
 
-          expect(heading.href(2)).to eq("index.html#apple-recipes")
+          expect(heading.href).to eq("index.html#apple-recipes")
         end
       end
     end
 
     describe "when page is not specified" do
-      describe "and level is 1" do
+      describe "and heading is h1" do
         it "returns a fragment href" do
-          heading = described_class.new(element_name: "", text: "", attributes: { "id" => "apple-recipes" })
+          heading = described_class.new(element_name: "h1", text: "", attributes: { "id" => "apple-recipes" })
 
-          expect(heading.href(1)).to eq("#apple-recipes")
+          expect(heading.href).to eq("#apple-recipes")
         end
       end
 
-      describe "and level is greater than 1" do
+      describe "and heading is not h1" do
         it "returns a fragment href" do
-          heading = described_class.new(element_name: "", text: "", attributes: { "id" => "apple-recipes" })
+          heading = described_class.new(element_name: "h2", text: "", attributes: { "id" => "apple-recipes" })
 
-          expect(heading.href(2)).to eq("#apple-recipes")
+          expect(heading.href).to eq("#apple-recipes")
         end
       end
     end

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -151,7 +151,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
 <ul><li><a href="/index.html"><span>Index</span></a>
 <ul>
   <li>
-    <a href="/a.html#heading-one"><span>Heading one</span></a>
+    <a href="/a.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/a.html#heading-two"><span>Heading two</span></a>
@@ -161,7 +161,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
 </ul>
 <ul>
   <li>
-    <a href="/b.html#heading-one"><span>Heading one</span></a>
+    <a href="/b.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/b.html#heading-two"><span>Heading two</span></a>
@@ -200,7 +200,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
 <ul><li><a href="/prefix/index.html"><span>Index</span></a>
 <ul>
   <li>
-    <a href="/prefix/a.html#heading-one"><span>Heading one</span></a>
+    <a href="/prefix/a.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/prefix/a.html#heading-two"><span>Heading two</span></a>
@@ -210,7 +210,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
 </ul>
 <ul>
   <li>
-    <a href="/prefix/b.html#heading-one"><span>Heading one</span></a>
+    <a href="/prefix/b.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/prefix/b.html#heading-two"><span>Heading two</span></a>
@@ -246,7 +246,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expected_multi_page_table_of_contents = %{
 <ul>
   <li>
-    <a href="/index.html#heading-one"><span>Heading one</span></a>
+    <a href="/index.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/index.html#heading-two"><span>Heading two</span></a>
@@ -254,7 +254,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
     </ul>
   </li>
   <li>
-    <a href="/index.html#heading-one"><span>Heading one</span></a>
+    <a href="/index.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/index.html#heading-two"><span>Heading two</span></a>
@@ -262,7 +262,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
     </ul>
   </li>
   <li>
-    <a href="/index.html#heading-one"><span>Heading one</span></a>
+    <a href="/index.html"><span>Heading one</span></a>
     <ul>
       <li>
         <a href="/index.html#heading-two"><span>Heading two</span></a>


### PR DESCRIPTION
⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️

## What

On loading a page initially `foo.html` do not change the URL to `foo.html#h1-id` until scrolling past.
Remove the fragment from the navigation for the `h1`.

## Why

It is expected that focus will begin at the start of the page. Changing this is confusing for screen reader users.

> On page load the main page heading is automatically focused. This may be navigationally disorientating for users reliant on the use of the keyboard alone to navigate.
> 
> Keyboard only user comments:
> “When this page loads, focus starts in the content of the page. I found this confusing as I expected my focus to start at the top of the page.”
> 
> Solution:
> Users would expect to navigate the page in reading order, from top to bottom and left to right.
>  

## Note

~I'm not sure about the navigation change... in itself it's not confusing as the target fragment is clear in the clicked link, but it still seems like the link to the "page" rather than "position on page" should be at the beginning. I'm going to double check this with DAC, but welcome any thoughts.~ Confirmed this is correct approach with DAC.