### PR TITLE
Fix focus state for search results ‘Close’ button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#240: Update menu html structure so it's one single hierarchical list](https://github.com/alphagov/tech-docs-gem/pull/240)
 - [#244: Don't change the focus of the page on initial load](https://github.com/alphagov/tech-docs-gem/pull/244)
 - [#243: Fix focus state for links containing inline code](https://github.com/alphagov/tech-docs-gem/pull/243)
+- [#245: Fix focus state for search results ‘Close’ button](https://github.com/alphagov/tech-docs-gem/pull/245)
 
 ## 2.3.0
 

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -130,16 +130,7 @@ html.has-search-results-open {
   cursor: pointer;
 
   &:focus {
-    background-color: $govuk-focus-colour;
-    outline: $govuk-focus-width solid transparent;
-    box-shadow: inset 0 0 0 1px $govuk-focus-colour;
-  }
-
-  &:focus:not(:active):not(:hover) {
-    border-color: $govuk-focus-colour;
-    color: $govuk-focus-text-colour;
-    background-color: $govuk-focus-colour;
-    box-shadow: 0 2px 0 $govuk-focus-text-colour;
+    @include govuk-focused-text;
   }
 
   &::after {


### PR DESCRIPTION
Use the mixin provided by GOV.UK Frontend to ensure that the focus style matches that used by other links.

## Before

<img width="908" alt="Screenshot 2021-07-14 at 16 48 34" src="https://user-images.githubusercontent.com/121939/125652243-4c6837e5-f8ea-4c5d-b7b4-42ed6d4d0c17.png">

## After

<img width="908" alt="Screenshot 2021-07-14 at 16 48 15" src="https://user-images.githubusercontent.com/121939/125652245-4c70f1bf-d438-4e91-b26b-f8fb50015a86.png">
