### PR TITLE
Release v2.4.0 containing various a11y fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.4.0
+
 - [Bump redcarpet to 3.5.1 to fix CVE-2020-26298](https://github.com/alphagov/tech-docs-gem/pull/226)
 - [#238: Move the aria-expanded attribute to the correct element](https://github.com/alphagov/tech-docs-gem/pull/238)
 - [#240: Update menu html structure so it's one single hierarchical list](https://github.com/alphagov/tech-docs-gem/pull/240)

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "2.3.0".freeze
+  VERSION = "2.4.0".freeze
 end


### PR DESCRIPTION
Sorry for goal hanging - all credit for this release to @colinbm  and @36degrees.

This just bumps the version number. I don't think it will be a breaking change for most users, so I figured a minor version bump was fine. Happy to change it if people think it's time for 3.0.