### PR TITLE
Release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.4.1
+
 - [#248: Remove IE8 fallback PNG with broken image reference](https://github.com/alphagov/tech-docs-gem/pull/248)
 
 ## 2.4.0

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "2.4.0".freeze
+  VERSION = "2.4.1".freeze
 end


### PR DESCRIPTION
This includes #248 which removes a broken image reference, which is currently preventing downstream projects from updating to v2.4.x.