### PR TITLE
Add note on ffi issue to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gem 'govuk_tech_docs', path: '../tech-docs-gem'
 
 To preview your documentation changes locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
-If you experience [this issue](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
+If you experience [this issue with ffi](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
 
 ### Use the example in this repo
 
@@ -48,7 +48,7 @@ bundle exec middleman server
 
 See your website on `http://localhost:4567` in your browser.
 
-If you experience [this issue](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
+If you experience [this issue with ffi](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
 
 For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
@@ -67,9 +67,9 @@ To run the tests and see the results in your terminal, run:
 bundle exec rake jasmine:ci
 ```
 
-## Issue with FFI on OSX Mohave
+## Issue with FFI on OSX Mojave
 
-Users on OSX Mohave (10.14) may get this error when running `bundle exec middleman serve` on apps that use this gem.
+Users on OSX Mojave (10.14) may get this error when running `bundle exec middleman serve` on apps that use this gem.
 
 There are 3 different ways to solve this, depending on what is possible for you. Listed here as best to worst:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gem 'govuk_tech_docs', path: '../tech-docs-gem'
 
 To preview your documentation changes locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
-If you experience [this issue with ffi](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
+If you experience [the FFI gem issue for Mojave users](https://github.com/alphagov/tech-docs-gem/issues/254), you should refer to this [list of possible fixes](#issue-with-ffi-on-osx-mohave).
 
 ### Use the example in this repo
 
@@ -48,7 +48,7 @@ bundle exec middleman server
 
 See your website on `http://localhost:4567` in your browser.
 
-If you experience [this issue with ffi](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
+If you experience [the FFI gem issue for Mojave users](https://github.com/alphagov/tech-docs-gem/issues/254), you should refer to this [list of possible fixes](#issue-with-ffi-on-osx-mohave).
 
 For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ bundle exec rake jasmine:ci
 
 Users on OSX Mojave (10.14) may get this error when running `bundle exec middleman serve` on apps that use this gem.
 
-There are 3 different ways to solve this, depending on what is possible for you. Listed here as best to worst:
+There are 3 possible ways to solve this. From best to worst, you can:
 
-1. upgrade to macOS 10.15 (Catalina) or higher
-2. tell rubygems not to use the system ffi (gem inst ffi -- --disable-system-libffi)
-3. pin the ffi version back to 1.12.2 in the Gemfile of your app
+* upgrade to macOS 10.15 (Catalina) or higher
+* tell rubygems not to use the system ffi by running `gem install ffi -- --disable-system-libffi` in the command line when the error shows
+* pin the ffi version back to 1.12.2 by editing the Gemfile of your app
 
 ## Releasing new versions
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ gem 'govuk_tech_docs', path: '../tech-docs-gem'
 
 To preview your documentation changes locally, see the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
+If you experience [this issue](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
+
 ### Use the example in this repo
 
 To start the example in this repo, run:
@@ -45,6 +47,8 @@ bundle exec middleman server
 ```
 
 See your website on `http://localhost:4567` in your browser.
+
+If you experience [this issue](https://github.com/alphagov/tech-docs-gem/issues/254), possible fixes can be found [here](#issue-with-ffi-on-osx-mohave).
 
 For more information on previewing your documentation locally, see the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
 
@@ -62,6 +66,16 @@ To run the tests and see the results in your terminal, run:
 ```
 bundle exec rake jasmine:ci
 ```
+
+## Issue with FFI on OSX Mohave
+
+Users on OSX Mohave (10.14) may get this error when running `bundle exec middleman serve` on apps that use this gem.
+
+There are 3 different ways to solve this, depending on what is possible for you. Listed here as best to worst:
+
+1. upgrade to macOS 10.15 (Catalina) or higher
+2. tell rubygems not to use the system ffi (gem inst ffi -- --disable-system-libffi)
+3. pin the ffi version back to 1.12.2 in the Gemfile of your app
 
 ## Releasing new versions
 


### PR DESCRIPTION
Users of apps consuming this gem and running on OSX Mohave (10.14) can experience an issue with the ffi gem.

This adds a note to the README listing fixes for the issue.

See https://github.com/alphagov/tech-docs-gem/issues/254 for related discussion.

I can see the warning about bumping the gem version but, looking at the history, this seems to be done as a separate PR, following those with code changes in.

⚠️ Don't forget to update the gem version in the [CHANGELOG](https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md) before merging! When you're ready to release bump [version file](https://github.com/alphagov/tech-docs-gem/blob/master/lib/govuk_tech_docs/version.rb) and generate a tag. ⚠️