### PR TITLE
Change search to only show results after submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking changes
+
+The search user experience is now more accessible for screenreader users. Search results are now on a separate page instead of a modal window.
+
+Users can no longer see search results as they type. They must press the Return key or select the search button to see the search results page.
+
+This was added in [pull request #263: Change search to only show results after submit](https://github.com/alphagov/tech-docs-gem/pull/263).
+
+### Fixes
+
 - [#265: Fix mark styles in Windows High Contrast Mode](https://github.com/alphagov/tech-docs-gem/pull/265)
 
 ## 2.4.3

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -190,7 +190,7 @@
     function updateTitle (text) {
       if (typeof text === 'undefined') {
         var count = results.length
-        var resultsText = count + ' results'
+        var resultsText = 'Search - ' + query + ' - ' + count + ' results'
       }
       $searchResultsTitle.text(text || resultsText)
     }

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -31,7 +31,7 @@
       changeSearchLabel()
 
       // Only do searches on the search page
-      if (window.location.pathname === '/search') {
+      if (window.location.pathname.match(/\/search(\/|\/index.html)?$/)) {
         $html.addClass('has-search-results-open')
 
         if (window.location.search) {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -13,11 +13,9 @@
     var $searchResults
     var $searchResultsTitle
     var $searchResultsWrapper
-    var $searchResultsClose
     var $searchHelp
     var results
     var query
-    var queryTimer
     var maxSearchEntries = 20
 
     this.start = function start ($element) {
@@ -27,16 +25,25 @@
       $searchResultsWrapper = $element.find('.search-results')
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
-      $searchResultsClose = $searchResultsWrapper.find('.search-results__close')
       $searchHelp = $('#search-help')
       $tocNav = $('#toc')
       s.downloadSearchIndex()
-      attach()
+      changeSearchAction()
       changeSearchLabel()
+
+      // Only do searches on the search page
+      if (window.location.pathname === '/search' && window.location.search) {
+        query = getQueryFromURL()
+        if (query) {
+          $searchInput.val(query)
+          doSearch(query)
+          doAnalytics()
+        }
+      }
     }
 
     this.downloadSearchIndex = function downloadSearchIndex () {
-      updateTitle('Loading search index')
+      updateTitle('Loading search results')
       $.ajax({
         url: '/search.json',
         cache: true,
@@ -50,46 +57,41 @@
       })
     }
 
-    function attach () {
-      // Search functionality on search text input
-      $searchInput.on('input', function (e) {
-        e.preventDefault()
-        query = $(this).val()
-        s.search(query, function (r) {
-          results = r
-          renderResults(query)
-          updateTitle()
-        })
-        if (window.ga) {
-          window.clearTimeout(queryTimer)
-          queryTimer = window.setTimeout(sendQueryToAnalytics, 1000)
-        }
-      })
+    function changeSearchAction () {
+      // We need JavaScript to do search, so if JS is not available the search
+      // input sends the query string to Google. This JS function changes the
+      // input to instead send it to the search page.
+      $searchForm.prop('action', '/search')
+      $searchForm.find('input[name="as_sitesearch"]').remove()
+    }
 
-      // Set focus on the first search result instead of submiting the search
-      // form to Google
-      $searchForm.on('submit', function (e) {
-        e.preventDefault()
-        showResults()
-        var $firstResult = $searchResults.find('.search-result__title a').first()
-        if ($firstResult.length) {
-          $firstResult.focus()
-        } else {
-          // if there are no results, show the "0 results" state
-          results = []
-          updateTitle()
-        }
-      })
+    function changeSearchLabel () {
+      $searchLabel.text('Search this documentation')
+    }
 
-      // Closing the search results, move focus back to the search input
-      $searchResultsClose.on('click', function (e) {
-        e.preventDefault()
-        $searchInput.focus()
-        hideResults()
-      })
+    function getQueryFromURL () {
+      var query = decodeURIComponent(
+        window.location.search
+          .match(/q=([^&]*)/)[1]
+          .replace(/\+/g, ' ')
+      )
+      return query
+    }
 
-      // Attach analytics events to search result clicks
+    function doSearch (query) {
+      s.search(query, function (r) {
+        results = r
+        renderResults(query)
+        updateTitle()
+      })
+    }
+
+    // TODO: remove this and sendQueryToAnalytics in a future breaking release
+    function doAnalytics () {
       if (window.ga) {
+        sendQueryToAnalytics()
+
+        // Attach analytics events to search result clicks
         $searchResults.on('click', '.search-result__title a', function () {
           var href = $(this).attr('href')
           ga('send', {
@@ -101,15 +103,6 @@
           })
         })
       }
-
-      // When selecting navigation link, close the search results.
-      $('#toc').on('click', 'a', function (e) {
-        hideResults()
-      })
-    }
-
-    function changeSearchLabel () {
-      $searchLabel.text('Search this documentation')
     }
 
     function getResults (query) {
@@ -124,7 +117,6 @@
 
     this.search = function search (query, callback) {
       if (query === '') {
-        hideResults()
         return
       }
       showResults()
@@ -204,13 +196,6 @@
         .attr('aria-hidden', 'false')
       $html.addClass('has-search-results-open')
       $tocNav.addClass('search-results-open')
-    }
-
-    function hideResults () {
-      $searchResultsWrapper.removeClass('is-open')
-        .attr('aria-hidden', 'true')
-      $html.removeClass('has-search-results-open')
-      $tocNav.removeClass('search-results-open')
     }
 
     function sendQueryToAnalytics () {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -6,7 +6,6 @@
   Modules.Search = function Search () {
     var s = this
     var $html = $('html')
-    var $tocNav
     var $searchForm
     var $searchLabel
     var $searchInput
@@ -26,18 +25,22 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
-      $tocNav = $('#toc')
+
       s.downloadSearchIndex()
       changeSearchAction()
       changeSearchLabel()
 
       // Only do searches on the search page
-      if (window.location.pathname === '/search' && window.location.search) {
-        query = getQueryFromURL()
-        if (query) {
-          $searchInput.val(query)
-          doSearch(query)
-          doAnalytics()
+      if (window.location.pathname === '/search') {
+        $html.addClass('has-search-results-open')
+
+        if (window.location.search) {
+          query = getQueryFromURL()
+          if (query) {
+            $searchInput.val(query)
+            doSearch(query)
+            doAnalytics()
+          }
         }
       }
     }
@@ -194,8 +197,6 @@
     function showResults () {
       $searchResultsWrapper.addClass('is-open')
         .attr('aria-hidden', 'false')
-      $html.addClass('has-search-results-open')
-      $tocNav.addClass('search-results-open')
       $searchHelp.attr('hidden', 'true')
     }
 

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -14,6 +14,7 @@
     var $searchResultsTitle
     var $searchResultsWrapper
     var $searchResultsClose
+    var $searchHelp
     var results
     var query
     var queryTimer
@@ -27,6 +28,7 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchResultsClose = $searchResultsWrapper.find('.search-results__close')
+      $searchHelp = $('#search-help')
       $tocNav = $('#toc')
       s.downloadSearchIndex()
       attach()

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -196,8 +196,7 @@
     }
 
     function showResults () {
-      $searchResultsWrapper.addClass('is-open')
-        .attr('aria-hidden', 'false')
+      $searchResultsWrapper.removeAttr('hidden')
       $searchHelp.attr('hidden', 'true')
     }
 

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -40,6 +40,7 @@
             $searchInput.val(query)
             doSearch(query)
             doAnalytics()
+            document.title = query + ' - ' + document.title
           }
         }
       }

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -22,7 +22,7 @@
       $searchForm = $element.find('form')
       $searchInput = $element.find('#search')
       $searchLabel = $element.find('.search__label')
-      $searchResultsWrapper = $element.find('.search-results')
+      $searchResultsWrapper = $('#search-results')
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
@@ -196,6 +196,7 @@
         .attr('aria-hidden', 'false')
       $html.addClass('has-search-results-open')
       $tocNav.addClass('search-results-open')
+      $searchHelp.attr('hidden', 'true')
     }
 
     function sendQueryToAnalytics () {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -26,16 +26,16 @@
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
 
-      s.downloadSearchIndex()
       changeSearchAction()
       changeSearchLabel()
 
       // Only do searches on the search page
-      if (window.location.pathname.match(/\/search(\/|\/index.html)?$/)) {
+      if (s.isOnSearchPage()) {
+        s.downloadSearchIndex()
         $html.addClass('has-search-results-open')
 
         if (window.location.search) {
-          query = getQueryFromURL()
+          query = s.getQuery()
           if (query) {
             $searchInput.val(query)
             doSearch(query)
@@ -73,7 +73,11 @@
       $searchLabel.text('Search this documentation')
     }
 
-    function getQueryFromURL () {
+    this.isOnSearchPage = function isOnSearchPage () {
+      return Boolean(window.location.pathname.match(/\/search(\/|\/index.html)?$/))
+    }
+
+    this.getQuery = function getQuery () {
       var query = decodeURIComponent(
         window.location.search
           .match(/q=([^&]*)/)[1]

--- a/lib/assets/javascripts/_modules/table-of-contents.js
+++ b/lib/assets/javascripts/_modules/table-of-contents.js
@@ -69,7 +69,6 @@
 
     function closeNavigation () {
       $html.removeClass('toc-open')
-      $html.removeClass('has-search-results-open')
 
       toggleBackgroundVisiblity(true)
       updateAriaAttributes()

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -70,13 +70,6 @@ $input-size: 40px;
 }
 
 .search-results {
-  display: none;
-  &.is-open {
-    display: block;
-  }
-}
-
-.search-results {
   @include govuk-media-query(tablet) {
     // Create basis for the search results caret (below)
     position: relative;

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -52,9 +52,20 @@ $input-size: 40px;
   }
 }
 
-html.has-search-results-open {
-  .toc__close{
-    display: none;
+@include govuk-media-query($until: tablet) {
+  html.js.has-search-results-open:not(.toc-open) {
+    .toc {
+      display: block;
+      padding-bottom: 0;
+    }
+
+    .toc__close {
+      display: none;
+    }
+
+    .toc__list {
+      display: none;
+    }
   }
 }
 

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -53,15 +53,11 @@ $input-size: 40px;
 }
 
 html.has-search-results-open {
-  overflow: hidden;
-  .app-pane__content {
-    overflow: hidden;
-  }
-  
   .toc__close{
     display: none;
   }
 }
+
 .search-results {
   display: none;
   &.is-open {
@@ -70,30 +66,26 @@ html.has-search-results-open {
 }
 
 .search-results {
-    position: absolute;
-    top: 60px;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 600;
-    overflow-x: scroll;
-    -webkit-overflow-scrolling: touch;
-    -ms-overflow-style: none;
-    @include govuk-media-query(tablet) {
-      padding: govuk-spacing(6);
-      top: 0;
-      // The width of the sidebar
-      left: 330px;
-      min-height: auto;
-    }
+  @include govuk-media-query(tablet) {
+    // Create basis for the search results caret (below)
+    position: relative;
 
-    a {
-      @include govuk-link-common;
-      @include govuk-link-style-no-visited-state;
-    }
+    @include govuk-font($size: 16);
+    padding-top: govuk-spacing(6);
   }
+
+  a {
+    @include govuk-link-common;
+    @include govuk-link-style-no-visited-state;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+}
 .search-results__inner {
-  position: relative;
   background: govuk-colour("white");
   border-top: 1px solid govuk-colour("mid-grey");
   max-width: 40rem;
@@ -104,7 +96,7 @@ html.has-search-results-open {
     &::after {
       content: '';
       position: absolute;
-      top: 10px;
+      top: 35px;
       left: -9px;
       width: 10px;
       height: 20px;

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -179,3 +179,7 @@ html.has-search-results-open {
     color: CanvasText;
   }
 }
+
+.js .search-help__no-js {
+  display: none;
+}

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -117,44 +117,6 @@ html.has-search-results-open {
   @include govuk-font($size: 27, $weight: bold);
   margin-bottom: govuk-spacing(6);
 }
-.search-results__close {
-  @include govuk-font($size: 16);
-  position: absolute;
-  top: 18px;
-  right: 20px;
-  appearance: none;
-  -webkit-appearance: none;
-  background: none;
-  border: 0;
-  padding: 0;
-  cursor: pointer;
-
-  &:focus {
-    @include govuk-focused-text;
-  }
-
-  &::after {
-    content: '';
-    display: inline-block;
-    vertical-align: middle;
-    padding-left: 8px;
-    height: 18px;
-    width: 18px;
-    background: no-repeat url('/images/govuk-icn-close.png') center right;
-    @include govuk-device-pixel-ratio {
-      background-image: url('/images/govuk-icn-close@2x.png');
-    }
-    background-size: contain;
-  }
-}
-.search-results__close-label {
-  position: absolute;
-  left: -9999em;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}
 .search-result {
   margin-bottom: govuk-spacing(6);
 }

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -11,10 +11,6 @@
     margin: 0 govuk-spacing(6) govuk-spacing(6);
   }
 
-  .has-search-results-open & {
-    visibility: hidden;
-  }
-
   > h1 {
     @extend %govuk-heading-xl;
 

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -165,9 +165,6 @@
 
       .toc__list {
         margin-right: govuk-spacing(7);
-        &.search-results-open {
-          display: none;
-        }
       }
 
       .toc__close {

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -117,6 +117,8 @@ module GovukTechDocs
 
         search.tokenizer_separator = '/[\s\-/]+/'
       end
+    else
+      context.ignore "search/*"
     end
   end
 end

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -13,11 +13,5 @@
       placeholder="Search">
     <button type="submit" class="search__button">Search</button>
   </form>
-  <div id="search-results" class="search-results" aria-hidden="true" role="dialog" aria-labelledby="search-results-title">
-    <div class="search-results__inner">
-      <h2 id="search-results-title" class="search-results__title" aria-live="assertive" role="alert">Results</h2>
-      <div class="search-results__content"></div>
-    </div>
-  </div>
 </div>
 <% end %>

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -15,7 +15,6 @@
   </form>
   <div id="search-results" class="search-results" aria-hidden="true" role="dialog" aria-labelledby="search-results-title">
     <div class="search-results__inner">
-      <button class="search-results__close">Close<span class="search-results__close-label"> search results</span></button>
       <h2 id="search-results-title" class="search-results__title" aria-live="assertive" role="alert">Results</h2>
       <div class="search-results__content"></div>
     </div>

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -6,7 +6,8 @@ hide_in_navigation: true
 ---
 
 <div id="search-help" class="search-help">
-  <h1>Search</h1>
+  <%# strange id is to avoid clash with search input id #%>
+  <h1 id="how-to-search">Search</h1>
 
   <p class="govuk-body search-help__no-js">
     This page requires JavaScript to perform searches. Please enable JavaScript, or use the search input to search using Google.

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -1,0 +1,18 @@
+---
+title: Search
+index: false
+prevent_indexing: true
+hide_in_navigation: true
+---
+
+<div id="search-help" class="search-help">
+  <h1>Search</h1>
+
+  <p class="govuk-body search-help__no-js">
+    This page requires JavaScript to perform searches. Please enable JavaScript, or use the search input to search using Google.
+  </p>
+
+  <p class="govuk-body">
+    Search the documentation using the search input.
+  </p>
+</div>

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -16,3 +16,10 @@ hide_in_navigation: true
     Search the documentation using the search input.
   </p>
 </div>
+
+<div id="search-results" class="search-results" aria-hidden="true" aria-labelledby="search-results-title">
+  <div class="search-results__inner">
+    <h2 id="search-results-title" class="search-results__title" aria-live="assertive" role="alert">Results</h2>
+    <div class="search-results__content"></div>
+  </div>
+</div>

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -20,7 +20,7 @@ hide_in_navigation: true
 
 <div id="search-results" class="search-results" aria-hidden="true" aria-labelledby="search-results-title">
   <div class="search-results__inner">
-    <h2 id="search-results-title" class="search-results__title" aria-live="assertive" role="alert">Results</h2>
+    <h2 id="search-results-title" class="search-results__title" aria-live="assertive">Results</h2>
     <div class="search-results__content"></div>
   </div>
 </div>

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -10,11 +10,16 @@ hide_in_navigation: true
   <h1 id="how-to-search">Search</h1>
 
   <p class="govuk-body search-help__no-js">
-    This page requires JavaScript to perform searches. Please enable JavaScript, or use the search input to search using Google.
+    You need to turn on JavaScript in your browser to search this site. You can either:
+
+    <ul>
+      <li>turn on JavaScript in your browser</li>
+      <li>search this site using Google</li>
+    </ul>
   </p>
 
   <p class="govuk-body">
-    Search the documentation using the search input.
+    Enter a search term in the search box, then select the search button.
   </p>
 </div>
 

--- a/lib/source/search/index.html.erb
+++ b/lib/source/search/index.html.erb
@@ -18,9 +18,9 @@ hide_in_navigation: true
   </p>
 </div>
 
-<div id="search-results" class="search-results" aria-hidden="true" aria-labelledby="search-results-title">
+<div id="search-results" class="search-results" hidden aria-labelledby="search-results-title">
   <div class="search-results__inner">
-    <h2 id="search-results-title" class="search-results__title" aria-live="assertive">Results</h2>
+    <h1 id="search-results-title" class="search-results__title" aria-live="assertive">Results</h1>
     <div class="search-results__content"></div>
   </div>
 </div>

--- a/spec/javascripts/search-spec.js
+++ b/spec/javascripts/search-spec.js
@@ -25,6 +25,15 @@ describe('Search', function () {
   '</div>' +
 '</div>')
 
+    // Stub out isOnSearchPage and getQuery
+    module.isOnSearchPage = function isOnSearchPage () {
+      return true
+    }
+
+    module.getQuery = function getQuery () {
+      return query
+    }
+
     // Change the default search index location to use the search index from the example app
     module.downloadSearchIndex = function downloadSearchIndex () {
       $.ajax({


### PR DESCRIPTION
Closes #262, hopefully.

The search user experience is now more accessible for screenreader users.

Users can no longer see search results as you type, they must hit enter or click the search button to see their results.

Adds a new page, `/search`, which is used to show search results. The JavaScript previously used to search the index and render results is still used, it has just been limited in scope to only working on this page. The search input is now progressively enhanced to point to the search page.

The intention is to try and create a more 'traditional' browser experience, which will make the user experience with assistive tech better.

This is not a breaking change for consumers of the gem, but it is a major change of the search user experience. Previously the search results would appear immediately as the user types, however now the user must hit enter or click the search button to see the search results. 

## Preview

I've deployed a version of the GOV.UK Frontend tech docs with this branch of govuk_tech_docs to make it easier to preview the changes in this pull request.

You can access the preview at https://deploy-preview-147--govuk-frontend-docs-preview.netlify.app/search/.

If you are a consumer of the `govuk_tech_docs` gem you should also try this version locally by changing the `Gemfile` to use this branch:

```diff
--- a/Gemfile
+++ b/Gemfile
-gem "govuk_tech_docs"
+gem "govuk_tech_docs", git: "https://github.com/alphagov/tech-docs-gem.git", branch: "ldeb-search-page"
```

## Screenshots

### Appearance of search results

| | Before | After |
|---|---|---|
| Chrome, desktop | <img width="1266" alt="search-results--before--chrome-desktop" src="https://user-images.githubusercontent.com/503614/134189021-311181e4-87f9-4a6f-8681-4ce4d1929b83.png"> | <img width="1266" alt="search-results--after--chrome-desktop" src="https://user-images.githubusercontent.com/503614/135473503-f73fdf63-3fad-4681-976f-f51d8d9c4ac9.png"> |
| Safari, iPhone 8 | <img width="325" alt="search-results--before--safari-iphone8" src="https://user-images.githubusercontent.com/503614/134190989-c8a411a8-3993-4bcd-bbaa-24fd4dd0216c.png"> | <img width="325" alt="search-results--after--safari-iphone8" src="https://user-images.githubusercontent.com/503614/135474294-d0f58501-91ed-4446-aa0a-a99a2e5561fe.png"> |

### Appearance of new search page

If the user visits the search page without a search query, a brief help page appears. If the user does not have JavaScript enabled the search page will not work, so there is also a help message that is visible only when JavaScript is not running.

| | |
|---|---|
| Chrome, desktop | <img width="1309" alt="search-page--chrome-desktop" src="https://user-images.githubusercontent.com/503614/136034560-ff299cd3-2752-490b-b144-a793061cbd6d.png"> |
| Safari, iPhone 8 | <img width="325" alt="search-page--safari-iphone8" src="https://user-images.githubusercontent.com/503614/136035194-0c026706-bf29-4c6a-b73e-a02ff624f87e.png"> |
| Safari, desktop, no JavaScript | <img width="1148" alt="search-page--safari-desktop-no-js" src="https://user-images.githubusercontent.com/503614/136035368-c5328cf3-886d-4b9d-b524-9a9621536185.png"> |

---

Work remaining:

- [x] Fix/add tests
- [x] Try and remove/push down the footer on the search page
- [x] Show search input in mobile viewport
- [x] Test with different assistive tech and browser combinations
- [x] Take to the accessibility clinic
- [x] Add to commit messages/release notes
- [x] Content review
- [ ] (stretch goal) Clean up and refactor the Sass and JS