### PR TITLE
Fix mark styles in Windows High Contrast Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#265: Fix mark styles in Windows High Contrast Mode](https://github.com/alphagov/tech-docs-gem/pull/265)
+
 ## 2.4.3
 
 - [#236: Fix search 'autocomplete' behaviour](https://github.com/alphagov/tech-docs-gem/pull/236)

--- a/lib/assets/stylesheets/modules/_search.scss
+++ b/lib/assets/stylesheets/modules/_search.scss
@@ -162,4 +162,20 @@ html.has-search-results-open {
   background-color: transparent;
   color: inherit;
   font-weight: bold;
+
+  // In forced color mode some browsers will keep the background transparent
+  // but set the text colour black, making the highlighted text unreadable.
+  // The following blocks fix this by setting the text colour to be the same as
+  // other text in a way that forced color mode will respect.
+
+  @media screen and (-ms-high-contrast: active) {
+    // IE does not support `CanvasText`,
+    // and `currentColor` does not work with Blink
+    color: currentColor;
+  }
+
+  @media screen and (forced-colors: active) {
+    background-color: Canvas;  // needed for Firefox
+    color: CanvasText;
+  }
 }


### PR DESCRIPTION
In some browsers (IE11, Chromium-based browsers) the marked text in search results are unreadable with forced colour modes when the background is black because the text colour for `<mark>` elements is set to black. This is especially present in Windows High Contrast Mode (HCM).

This commit fixes this by re-asserting that the marked text should be the same colour as the surrounding text.

We also have to set `background-color: Canvas`, because in Firefox `background-color: transparent` is also ignored (unlike in IE11, Chromiums).

### Screenshots

| | Before | After |
|---|---|---|
| Edge | <img width="250" alt="mark--before--edge" src="https://user-images.githubusercontent.com/503614/134657790-c28aa3f1-7946-4c24-ab5b-568a12c51f80.png"> | <img width="250" alt="mark--after--edge" src="https://user-images.githubusercontent.com/503614/134657559-1d51f1ee-c078-4c57-ae1c-62f8cd2422dc.png"> |
| Edge, HCM | <img width="250" alt="mark--before--edge-hcm" src="https://user-images.githubusercontent.com/503614/134656198-3a54c2e8-e66f-415e-bd03-a0d60d92d617.png"> | <img width="250" alt="mark--after--edge-hcm" src="https://user-images.githubusercontent.com/503614/134656327-3219d770-4758-4833-be14-b6571a73f13c.png"> |
| IE11, HCM | <img width="250" alt="mark--before--ie11-hcm" src="https://user-images.githubusercontent.com/503614/134656462-0dbbbe9e-18eb-47f5-9816-bd300b34f065.png"> | <img width="250" alt="mark--after--ie11-hcm" src="https://user-images.githubusercontent.com/503614/134656669-b5a48f86-7e44-4c01-937e-f84e824a3318.png"> |
| Firefox, HCM | <img width="250" alt="mark--before--firefox-hcm" src="https://user-images.githubusercontent.com/503614/134656883-2e3d827a-d7af-40ee-a7b1-24c9ac51ef94.png"> | <img width="250" alt="mark--after--firefox-hcm" src="https://user-images.githubusercontent.com/503614/134656967-423bc0d7-6ef0-47e8-9907-8b4a7e3da195.png"> | 