### PR TITLE
Don't construct `report_issue_url` through string manipulation

### DIFF
--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -20,12 +20,18 @@ module GovukTechDocs
 
     def report_issue_url
       url = config[:source_urls]&.[](:report_issue_url)
+      params = {
+        body: "Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})",
+      }
 
       if url.nil?
-        "#{repo_url}/issues/new?labels=bug&title=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+        url = "#{repo_url}/issues/new"
+        params["labels"] = "bug"
+        params["title"] = "Re: '#{current_page.data.title}'"
       else
-        "#{url}?subject=Re: '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+        params["subject"] = "Re: '#{current_page.data.title}'"
       end
+      "#{url}?#{URI.encode_www_form(params)}"
     end
 
     def repo_url

--- a/spec/govuk_tech_docs/source_urls_spec.rb
+++ b/spec/govuk_tech_docs/source_urls_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GovukTechDocs::SourceUrls do
       config = generate_config("test/repo", "https://test-docs/")
       source_urls = GovukTechDocs::SourceUrls.new(current_page, config)
 
-      expect(source_urls.report_issue_url).to eql("https://github.com/test/repo/issues/new?labels=bug&title=Re: 'title'&body=Problem with 'title' (https://test-docs/url)")
+      expect(source_urls.report_issue_url).to eql("https://github.com/test/repo/issues/new?body=Problem+with+%27title%27+%28https%3A%2F%2Ftest-docs%2Furl%29&labels=bug&title=Re%3A+%27title%27")
     end
 
     it "uses a custom URL when configured" do
@@ -18,7 +18,7 @@ RSpec.describe GovukTechDocs::SourceUrls do
       }
       source_urls = GovukTechDocs::SourceUrls.new(current_page, config)
 
-      expect(source_urls.report_issue_url).to eql("mailto:test@example.com?subject=Re: 'title'&body=Problem with 'title' (https://test-docs/url)")
+      expect(source_urls.report_issue_url).to eql("mailto:test@example.com?body=Problem+with+%27title%27+%28https%3A%2F%2Ftest-docs%2Furl%29&subject=Re%3A+%27title%27")
     end
   end
 


### PR DESCRIPTION
Instead of constructing the URL for reporting an issue by manipulating
the raw string, we can instead use the `URI.encode_www_form`[0] method.

This ensures that we're constructing the URL as a well-formed, encoded
set of parameters, and has the added benefit of it being much clearer to
read, too.

[0]: https://stackoverflow.com/a/11251654
