### PR TITLE
Fix CI

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "autoprefixer-rails", "~> 10.2"
   spec.add_dependency "chronic", "~> 0.10.2"
-  spec.add_dependency "middleman", "~> 4.0"
+  spec.add_dependency "middleman", "~> 4.0", "!= 4.4.1"
   spec.add_dependency "middleman-autoprefixer", "~> 2.10.0"
   spec.add_dependency "middleman-compass", ">= 4.0.0"
   spec.add_dependency "middleman-livereload"


### PR DESCRIPTION
A v4.4.1 version of middleman was released yesterday that seems to be broken (see for instance failed tests on main branch https://github.com/alphagov/tech-docs-gem/runs/4095543211?check_suite_focus=true).

This PR adds a requirement to the gemspec that rejects this version, so our users won't install it. It also fixes our tests.
