### PR TITLE
Update to GOV.UK Frontend v4.0.0

### DIFF
--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -41,9 +41,9 @@
     </div>
     <% if config[:tech_docs][:header_links] %>
     <div class="govuk-header__content">
-      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-      <nav>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+      <nav class="govuk-header__navigation govuk-header__navigation--end" aria-label="Menu">
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu">Menu</button>
+        <ul id="navigation" class="govuk-header__navigation-list">
           <% config[:tech_docs][:header_links].each do |title, path| %>
             <li class="govuk-header__navigation-item<% if active_page(path) %> govuk-header__navigation-item--active<% end %>">
               <a class="govuk-header__link" href="<%= url_for path %>"><%= title %></a>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -27,7 +27,7 @@
 
     <div class="app-pane">
       <div class="app-pane__header toc-open-disabled">
-        <a href="#content" class="govuk-skip-link">Skip to main content</a>
+        <a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
         <%= partial 'layouts/header' %>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
-      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard"
   },
   "dependencies": {
-    "govuk-frontend": "^3.13.0"
+    "govuk-frontend": "^4.0.0"
   },
   "devDependencies": {
     "standard": "^14.3.4"


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

Updating to GOV.UK Frontend v4.0.0. This is a draft PR based against the latest pre-release. The PR will be updated to the actual release once it's live on npm.

## Things I checked

The tech docs gem:

- **does not** use any accordions
- **does not** use any summary lists
- **does not** use a cookie banner
- **does not** use hints
- **does not** use error messages
- **does not** use any conditional reveals
- **does not** use any character counts
- **does not** import JavaScript modules individually
- **does not** import Sass template file
- **does not** use footer sections (only uses the `meta` option)
- **does not** use `$govuk-border-width-form-element-error`
- **does not** use `govuk-main-wrapper` or `govuk-main-wrapper--l` mixins
- **does not** use Sass `iff` function
- **does not** use `govuk-tag--inactive` class
- **does not** use any date inputs
- already uses `aria-hidden="true"` for the header, button and footer SVGs
- already imports `base` before `core`/`overrides`

I've added commits for:

- changing the header HTML, to move the button element, `aria` attribute and move/add the relevant classes
- initialising the skip link JavaScript by adding `data-module="govuk-skip-link"`
