### PR TITLE
Release v3.0.1

### DIFF
--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1".freeze
 end


### PR DESCRIPTION
### Fixes

We’ve made the following fixes to the tech docs gem in [pull request #281: Don't break TOC when OpenAPI description includes headers](https://github.com/alphagov/tech-docs-gem/pull/281): 

* we now render OpenAPI Markdown with the same Markdown renderer as other documents
* table of contents (TOC) uses `TechDocsHTMLRenderer` to render the headings with IDs

Thanks to [@jamietanna](https://github.com/jamietanna) for contributing to this issue and its solution.