### PR TITLE
Support sites deployed on paths other than "/" (by generating relative links)

### DIFF
--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -57,25 +57,31 @@
       $toggleLabel.text(setOpen ? 'Collapse ' + $heading.text() : 'Expand ' + $heading.text())
     }
 
+    /**
+     * Returns an absolute pathname to $target by combining it with window.location.href
+     * @param $target The target whose pathname to return. This may be an anchor with an absolute or relative href.
+     * @returns {string} The absolute pathname of $target
+     */
+    function getAbsolutePath ($target) {
+      return new URL($target.attr('href'), window.location.href).pathname
+    }
+
     function openActiveHeading () {
       var $activeElement
       var currentPath = window.location.pathname
-      var isActiveTrail = '[href*="' + currentPath + '"]'
-      // Add an exception for the root page, as every href includes /
-      if (currentPath === '/') {
-        isActiveTrail = '[href="' + currentPath + window.location.hash + '"]'
-      }
       for (var i = $topLevelItems.length - 1; i >= 0; i--) {
         var $element = $($topLevelItems[i])
         var $heading = $element.find('> a')
         // Check if this item href matches
-        if ($heading.is(isActiveTrail)) {
+        if (getAbsolutePath($heading) === currentPath) {
           $activeElement = $element
           break
         }
         // Otherwise check the children
         var $children = $element.find('li > a')
-        var $matchingChildren = $children.filter(isActiveTrail)
+        var $matchingChildren = $children.filter(function (_) {
+          return getAbsolutePath($(this)) === currentPath
+        })
         if ($matchingChildren.length) {
           $activeElement = $element
           break

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -70,13 +70,18 @@
     function highlightActiveItemInToc (fragment) {
       // Navigation items for single page navigation don't necessarily include the path name, but
       // navigation items for multipage navigation items do include it. This checks for either case.
-      var $activeTocItem = $tocItems.filter(
-        '[href="' + window.location.pathname + fragment + '"],[href="' + fragment + '"]'
-      )
+      var $activeTocItem = $tocItems.filter(function (_) {
+        var url = new URL($(this).attr('href'), window.location.href)
+        return url.href === window.location.href
+      })
+
       // Navigation items with children don't contain fragments in their url
       // Check to see if any nav items contain just the path name.
       if (!$activeTocItem.get(0)) {
-        $activeTocItem = $tocItems.filter('[href="' + window.location.pathname + '"]')
+        $activeTocItem = $tocItems.filter(function (_) {
+          const url = new URL($(this).attr('href'), window.location.href)
+          return url.hash === '' && url.pathname === window.location.pathname
+        })
       }
       if ($activeTocItem.get(0)) {
         $tocItems.removeClass('toc-link--in-view')

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -79,7 +79,7 @@
       // Check to see if any nav items contain just the path name.
       if (!$activeTocItem.get(0)) {
         $activeTocItem = $tocItems.filter(function (_) {
-          const url = new URL($(this).attr('href'), window.location.href)
+          var url = new URL($(this).attr('href'), window.location.href)
           return url.hash === '' && url.pathname === window.location.pathname
         })
       }

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -30,7 +30,7 @@
       searchIndexPath = $element.data('searchIndexPath')
       pathToSiteRoot = $element.data('pathToSiteRoot')
 
-      changeSearchAction(pathToSiteRoot)
+      changeSearchAction()
       changeSearchLabel()
 
       // Only do searches on the search page
@@ -65,7 +65,7 @@
       })
     }
 
-    function changeSearchAction (pathToSiteRoot) {
+    function changeSearchAction () {
       // We need JavaScript to do search, so if JS is not available the search
       // input sends the query string to Google. This JS function changes the
       // input to instead send it to the search page.

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -153,7 +153,7 @@
         var content = s.processContent(result.content, query)
         output += '<li class="search-result">'
         output += '<h3 class="search-result__title">'
-        const url = result.url.startsWith('/') ? result.url.slice(1) : result.url
+        var url = result.url.startsWith('/') ? result.url.slice(1) : result.url
         output += '<a href="' + pathToSiteRoot + url + '">'
         output += result.title
         output += '</a>'

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -153,8 +153,9 @@
         var content = s.processContent(result.content, query)
         output += '<li class="search-result">'
         output += '<h3 class="search-result__title">'
-        var url = result.url.startsWith('/') ? result.url.slice(1) : result.url
-        output += '<a href="' + pathToSiteRoot + url + '">'
+        var pagePathWithoutLeadingSlash = result.url.startsWith('/') ? result.url.slice(1) : result.url
+        var url = pathToSiteRoot.startsWith('.') ? pathToSiteRoot + pagePathWithoutLeadingSlash : '/' + pagePathWithoutLeadingSlash
+        output += '<a href="' + url + '">'
         output += result.title
         output += '</a>'
         output += '</h3>'

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -78,8 +78,7 @@
     }
 
     this.isOnSearchPage = function isOnSearchPage () {
-      // .* prefix is used to match sites which use relative links.
-      return Boolean(window.location.pathname.match(/.*\/search(\/|\/index.html)?$/))
+      return Boolean(window.location.pathname.match(/\/search(\/|\/index.html)?$/))
     }
 
     this.getQuery = function getQuery () {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -16,6 +16,7 @@
     var results
     var query
     var maxSearchEntries = 20
+    var pathToSiteRoot
     var searchIndexPath
 
     this.start = function start ($element) {
@@ -27,8 +28,9 @@
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
       searchIndexPath = $element.data('searchIndexPath')
+      pathToSiteRoot = $element.data('pathToSiteRoot')
 
-      changeSearchAction()
+      changeSearchAction(pathToSiteRoot)
       changeSearchLabel()
 
       // Only do searches on the search page
@@ -40,7 +42,7 @@
           query = s.getQuery()
           if (query) {
             $searchInput.val(query)
-            doSearch(query)
+            doSearch(query, pathToSiteRoot)
             doAnalytics()
             document.title = query + ' - ' + document.title
           }
@@ -51,7 +53,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search results')
       $.ajax({
-        url: searchIndexPath,
+        url: pathToSiteRoot + (searchIndexPath.startsWith('/') ? searchIndexPath.slice(1) : searchIndexPath),
         cache: true,
         method: 'GET',
         success: function (data) {
@@ -63,11 +65,11 @@
       })
     }
 
-    function changeSearchAction () {
+    function changeSearchAction (pathToSiteRoot) {
       // We need JavaScript to do search, so if JS is not available the search
       // input sends the query string to Google. This JS function changes the
       // input to instead send it to the search page.
-      $searchForm.prop('action', '/search')
+      $searchForm.prop('action', pathToSiteRoot + 'search/index.html')
       $searchForm.find('input[name="as_sitesearch"]').remove()
     }
 
@@ -76,7 +78,8 @@
     }
 
     this.isOnSearchPage = function isOnSearchPage () {
-      return Boolean(window.location.pathname.match(/\/search(\/|\/index.html)?$/))
+      // .* prefix is used to match sites which use relative links.
+      return Boolean(window.location.pathname.match(/.*\/search(\/|\/index.html)?$/))
     }
 
     this.getQuery = function getQuery () {
@@ -88,10 +91,10 @@
       return query
     }
 
-    function doSearch (query) {
+    function doSearch (query, pathToSiteRoot) {
       s.search(query, function (r) {
         results = r
-        renderResults(query)
+        renderResults(query, pathToSiteRoot)
         updateTitle()
       })
     }
@@ -140,7 +143,7 @@
       callback(getResults(query))
     }
 
-    function renderResults (query) {
+    function renderResults (query, pathToSiteRoot) {
       var output = ''
       if (results.length === 0) {
         output += '<p>Nothing found</p>'
@@ -151,7 +154,8 @@
         var content = s.processContent(result.content, query)
         output += '<li class="search-result">'
         output += '<h3 class="search-result__title">'
-        output += '<a href="' + result.url + '">'
+        const url = result.url.startsWith('/') ? result.url.slice(1) : result.url
+        output += '<a href="' + pathToSiteRoot + url + '">'
         output += result.title
         output += '</a>'
         output += '</h3>'

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -17,7 +17,6 @@
     var query
     var maxSearchEntries = 20
     var pathToSiteRoot
-    var searchIndexPath
 
     this.start = function start ($element) {
       $searchForm = $element.find('form')
@@ -27,7 +26,6 @@
       $searchResults = $searchResultsWrapper.find('.search-results__content')
       $searchResultsTitle = $searchResultsWrapper.find('.search-results__title')
       $searchHelp = $('#search-help')
-      searchIndexPath = $element.data('searchIndexPath')
       pathToSiteRoot = $element.data('pathToSiteRoot')
 
       changeSearchAction()
@@ -53,7 +51,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search results')
       $.ajax({
-        url: pathToSiteRoot + (searchIndexPath.startsWith('/') ? searchIndexPath.slice(1) : searchIndexPath),
+        url: pathToSiteRoot + 'search.json',
         cache: true,
         method: 'GET',
         success: function (data) {

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -67,6 +67,7 @@ module GovukTechDocs
     context.activate :api_reference
 
     context.helpers do
+      include GovukTechDocs::PathHelpers
       include GovukTechDocs::TableOfContents::Helpers
       include GovukTechDocs::ContributionBanner
 

--- a/lib/govuk_tech_docs/pages.rb
+++ b/lib/govuk_tech_docs/pages.rb
@@ -20,7 +20,7 @@ module GovukTechDocs
         review = PageReview.new(page, @config)
         {
           title: page.data.title,
-          url: "#{get_path_to_resource(@config, page, @current_page)}",
+          url: get_path_to_resource(@config, page, @current_page).to_s,
           review_by: review.review_by,
           owner_slack: review.owner_slack,
         }

--- a/lib/govuk_tech_docs/pages.rb
+++ b/lib/govuk_tech_docs/pages.rb
@@ -1,10 +1,12 @@
 module GovukTechDocs
   class Pages
+    include GovukTechDocs::PathHelpers
     attr_reader :sitemap
 
-    def initialize(sitemap, config)
+    def initialize(sitemap, config, current_page)
       @sitemap = sitemap
       @config = config
+      @current_page = current_page
     end
 
     def to_json(*_args)
@@ -18,7 +20,7 @@ module GovukTechDocs
         review = PageReview.new(page, @config)
         {
           title: page.data.title,
-          url: "#{@config[:tech_docs][:host]}#{page.url}",
+          url: "#{get_path_to_resource(@config, page, @current_page)}",
           review_by: review.review_by,
           owner_slack: review.owner_slack,
         }

--- a/lib/govuk_tech_docs/path_helpers.rb
+++ b/lib/govuk_tech_docs/path_helpers.rb
@@ -17,13 +17,9 @@ module GovukTechDocs
 
     def path_to_site_root(config, page_path)
       if config[:relative_links]
-        number_of_ascents_to_site_root = page_path.to_s.split("/").reject(&:empty?)[0..-2].length()
-        if number_of_ascents_to_site_root == 0
-          ascents = ["."]
-        else
-          ascents = number_of_ascents_to_site_root.times.collect { ".." }
-        end
-        path_to_site_root = ascents.join("/").concat('/')
+        number_of_ascents_to_site_root = page_path.to_s.split("/").reject(&:empty?)[0..-2].length
+        ascents = number_of_ascents_to_site_root.zero? ? ["."] : number_of_ascents_to_site_root.times.collect { ".." }
+        path_to_site_root = ascents.join("/").concat("/")
       else
         path_to_site_root = "/"
       end

--- a/lib/govuk_tech_docs/path_helpers.rb
+++ b/lib/govuk_tech_docs/path_helpers.rb
@@ -21,7 +21,8 @@ module GovukTechDocs
         ascents = number_of_ascents_to_site_root.zero? ? ["."] : number_of_ascents_to_site_root.times.collect { ".." }
         path_to_site_root = ascents.join("/").concat("/")
       else
-        path_to_site_root = "/"
+        middleman_http_prefix = config[:http_prefix]
+        path_to_site_root = middleman_http_prefix.end_with?("/") ? middleman_http_prefix : "#{middleman_http_prefix}/"
       end
       path_to_site_root
     end

--- a/lib/govuk_tech_docs/path_helpers.rb
+++ b/lib/govuk_tech_docs/path_helpers.rb
@@ -1,0 +1,33 @@
+module GovukTechDocs
+  module PathHelpers
+    def get_path_to_resource(config, resource, current_page)
+      if config[:relative_links]
+        resource_path_segments = resource.path.split("/").reject(&:empty?)[0..-2]
+        resource_file_name = resource.path.split("/")[-1]
+
+        path_to_site_root = path_to_site_root config, current_page.path
+        resource_path = path_to_site_root + resource_path_segments
+                                           .push(resource_file_name)
+                                           .join("/")
+      else
+        resource_path = resource.url
+      end
+      resource_path
+    end
+
+    def path_to_site_root(config, page_path)
+      if config[:relative_links]
+        number_of_ascents_to_site_root = page_path.to_s.split("/").reject(&:empty?)[0..-2].length()
+        if number_of_ascents_to_site_root == 0
+          ascents = ["."]
+        else
+          ascents = number_of_ascents_to_site_root.times.collect { ".." }
+        end
+        path_to_site_root = ascents.join("/").concat('/')
+      else
+        path_to_site_root = "/"
+      end
+      path_to_site_root
+    end
+  end
+end

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -51,11 +51,7 @@ module GovukTechDocs
 
           # Reuse the generated content for the active page
           # If we generate it twice it increments the heading ids
-          content = if current_page.url == resource.url && current_page_html
-                      current_page_html
-                    else
-                      resource.render(layout: false)
-                    end
+          content = current_page.url == resource.url && current_page_html ? current_page_html : resource.render(layout: false)
           # Avoid redirect pages
           next if content.include? "http-equiv=refresh"
 

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -59,6 +59,22 @@ module GovukTechDocs
         link_value
       end
 
+      def path_to_site_root(*args, &block)
+        if config[:relative_links]
+          current_page_url = args[0]
+          number_of_ascents_to_site_root = current_page_url.to_s.split("/").length() - 1
+          if number_of_ascents_to_site_root == 0
+            ascents = ["."]
+          else
+            ascents = number_of_ascents_to_site_root.times.collect { ".." }
+          end
+          path_to_site_root = ascents.join("/").concat('/')
+        else
+          path_to_site_root = "/"
+        end
+        path_to_site_root
+      end
+
       def render_page_tree(resources, current_page, config, current_page_html)
         # Sort by weight frontmatter
         resources = resources

--- a/lib/source/api/pages.json.erb
+++ b/lib/source/api/pages.json.erb
@@ -1,1 +1,1 @@
-<%= GovukTechDocs::Pages.new(sitemap, config).to_json %>
+<%= GovukTechDocs::Pages.new(sitemap, config, current_page).to_json %>

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search" data-search-index-path="<%= search_index_path %>">
+<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root current_page.path %>" data-search-index-path="<%= search_index_path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root config, current_page.path %>" data-search-index-path="<%= search_index_path %>">
+<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root config, current_page.path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -1,5 +1,5 @@
 <% if config[:tech_docs][:enable_search] %>
-<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root current_page.path %>" data-search-index-path="<%= search_index_path %>">
+<div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root config, current_page.path %>" data-search-index-path="<%= search_index_path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label class="govuk-label search__label" for="search" aria-hidden="true">

--- a/spec/govuk_tech_docs/pages_spec.rb
+++ b/spec/govuk_tech_docs/pages_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GovukTechDocs::Pages do
         double(url: "/b/c.html", path: "/b/c.html", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "2 days")),
       ])
 
-      json = described_class.new(sitemap, {:relative_links => true}, current_page).to_json
+      json = described_class.new(sitemap, { relative_links: true }, current_page).to_json
 
       expect(JSON.parse(json)).to eql([
         { "title" => "A thing", "url" => "../a.html", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" },

--- a/spec/govuk_tech_docs/pages_spec.rb
+++ b/spec/govuk_tech_docs/pages_spec.rb
@@ -1,16 +1,32 @@
 RSpec.describe GovukTechDocs::Pages do
   describe "#to_json" do
-    it "returns the pages as JSON" do
+    it "returns the pages as JSON when using absolute links" do
+      current_page = double(path: "/api/pages.json")
       sitemap = double(resources: [
         double(url: "/a.html", data: double(title: "A thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "0 days")),
         double(url: "/b.html", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "2 days")),
       ])
 
-      json = described_class.new(sitemap, tech_docs: {}).to_json
+      json = described_class.new(sitemap, {}, current_page).to_json
 
       expect(JSON.parse(json)).to eql([
         { "title" => "A thing", "url" => "/a.html", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" },
         { "title" => "B thing", "url" => "/b.html", "review_by" => Date.tomorrow.to_s, "owner_slack" => "#2ndline" },
+      ])
+    end
+
+    it "returns the pages as JSON when using relative links" do
+      current_page = double(path: "/api/pages.json")
+      sitemap = double(resources: [
+        double(url: "/a.html", path: "/a.html", data: double(title: "A thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "0 days")),
+        double(url: "/b/c.html", path: "/b/c.html", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_on: Date.yesterday, review_in: "2 days")),
+      ])
+
+      json = described_class.new(sitemap, {:relative_links => true}, current_page).to_json
+
+      expect(JSON.parse(json)).to eql([
+        { "title" => "A thing", "url" => "../a.html", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" },
+        { "title" => "B thing", "url" => "../b/c.html", "review_by" => Date.tomorrow.to_s, "owner_slack" => "#2ndline" },
       ])
     end
   end

--- a/spec/govuk_tech_docs/path_helpers_spec.rb
+++ b/spec/govuk_tech_docs/path_helpers_spec.rb
@@ -1,11 +1,9 @@
-
-
 RSpec.describe GovukTechDocs::PathHelpers do
   include GovukTechDocs::PathHelpers
 
   describe "#get_path_to_resource" do
     it "calculates the path to a resource when using absolute links" do
-      resource_url = '/documentation/introduction/index.html'
+      resource_url = "/documentation/introduction/index.html"
 
       config = {}
       resource = double("resource", url: resource_url)
@@ -15,39 +13,39 @@ RSpec.describe GovukTechDocs::PathHelpers do
     end
 
     it "calculates the path to a resource when using relative links" do
-      current_page_path = '/documentation/introduction/section-one/index.html'
-      url = '/documentation/introduction/index.html'
+      current_page_path = "/documentation/introduction/section-one/index.html"
+      url = "/documentation/introduction/index.html"
 
       config = {
-        :relative_links => true
+        relative_links: true,
       }
       resource = double("resource", url: url, path: url)
       current_page = double("current_page", path: current_page_path)
 
       resource_path = get_path_to_resource(config, resource, current_page)
-      expect(resource_path).to eql('../../../documentation/introduction/index.html')
+      expect(resource_path).to eql("../../../documentation/introduction/index.html")
     end
   end
 
   describe "#path_to_site_root" do
     it "calculates the path from a page to the site root when using absolute links" do
-      page_path = '/documentation/introduction/index.html'
+      page_path = "/documentation/introduction/index.html"
 
       config = {}
 
       path_to_site_root = path_to_site_root(config, page_path)
-      expect(path_to_site_root).to eql('/')
+      expect(path_to_site_root).to eql("/")
     end
 
     it "calculates the path from a page to the site root when using relative links" do
-      page_path = '/documentation/introduction/index.html'
+      page_path = "/documentation/introduction/index.html"
 
       config = {
-        :relative_links => true
+        relative_links: true,
       }
 
       path_to_site_root = path_to_site_root(config, page_path)
-      expect(path_to_site_root).to eql('../../')
+      expect(path_to_site_root).to eql("../../")
     end
   end
 end

--- a/spec/govuk_tech_docs/path_helpers_spec.rb
+++ b/spec/govuk_tech_docs/path_helpers_spec.rb
@@ -31,10 +31,23 @@ RSpec.describe GovukTechDocs::PathHelpers do
     it "calculates the path from a page to the site root when using absolute links" do
       page_path = "/documentation/introduction/index.html"
 
-      config = {}
+      config = {
+        http_prefix: "/", # This is Middleman's default setting.
+      }
 
       path_to_site_root = path_to_site_root(config, page_path)
       expect(path_to_site_root).to eql("/")
+    end
+
+    it "calculates the path from a page to the site root when a middleman http prefix" do
+      page_path = "/bananas/documentation/introduction/index.html"
+
+      config = {
+        http_prefix: "/bananas",
+      }
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql("/bananas/")
     end
 
     it "calculates the path from a page to the site root when using relative links" do

--- a/spec/govuk_tech_docs/path_helpers_spec.rb
+++ b/spec/govuk_tech_docs/path_helpers_spec.rb
@@ -1,0 +1,53 @@
+
+
+RSpec.describe GovukTechDocs::PathHelpers do
+  include GovukTechDocs::PathHelpers
+
+  describe "#get_path_to_resource" do
+    it "calculates the path to a resource when using absolute links" do
+      resource_url = '/documentation/introduction/index.html'
+
+      config = {}
+      resource = double("resource", url: resource_url)
+
+      resource_path = get_path_to_resource(config, resource, nil)
+      expect(resource_path).to eql(resource_url)
+    end
+
+    it "calculates the path to a resource when using relative links" do
+      current_page_path = '/documentation/introduction/section-one/index.html'
+      url = '/documentation/introduction/index.html'
+
+      config = {
+        :relative_links => true
+      }
+      resource = double("resource", url: url, path: url)
+      current_page = double("current_page", path: current_page_path)
+
+      resource_path = get_path_to_resource(config, resource, current_page)
+      expect(resource_path).to eql('../../../documentation/introduction/index.html')
+    end
+  end
+
+  describe "#path_to_site_root" do
+    it "calculates the path from a page to the site root when using absolute links" do
+      page_path = '/documentation/introduction/index.html'
+
+      config = {}
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql('/')
+    end
+
+    it "calculates the path from a page to the site root when using relative links" do
+      page_path = '/documentation/introduction/index.html'
+
+      config = {
+        :relative_links => true
+      }
+
+      path_to_site_root = path_to_site_root(config, page_path)
+      expect(path_to_site_root).to eql('../../')
+    end
+  end
+end

--- a/spec/javascripts/search-spec.js
+++ b/spec/javascripts/search-spec.js
@@ -10,7 +10,7 @@ describe('Search', function () {
 
   beforeEach(function () {
     module = new GOVUK.Modules.Search()
-    $element = $('<div class="search" data-module="search">' +
+    $element = $('<div class="search" data-module="search" data-path-to-site-root="/">' +
   '<form action="https://www.google.co.uk/search" method="get" role="search">' +
     '<input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>' +
     '<label for="search"  class="govuk-label search__label">Search (via Google)</label>' +

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -281,7 +281,6 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
     end
 
-    #TODO: Assess whether this test is still relevant given that we are now generating relative links.
     it "builds a table of contents from several page resources with a custom http prefix configured" do
       resources = []
       resources[0] = FakeResource.new("/prefix/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -126,16 +126,20 @@ describe GovukTechDocs::TableOfContents::Helpers do
 
     subject { Subject.new }
 
-    it "builds a table of contents from several page resources" do
+    it "builds a table of contents using absolute links from several page resources" do
       resources = []
       resources[0] = FakeResource.new("/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
-      resources[1] = FakeResource.new("/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Sub page A", resources[0]);
-      resources[2] = FakeResource.new("/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page B", resources[0]);
-      resources[0].add_children [resources[1], resources[2]]
+      resources[1] = FakeResource.new("/1/2/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page A", resources[0]);
+      resources[2] = FakeResource.new("/1/2/3/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 30, "Sub page A", resources[0]);
+      resources[3] = FakeResource.new("/1/2/3/4/c.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 40, "Sub page B", resources[0]);
+      resources[4] = FakeResource.new("/1/5/d.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 50, "Sub page A", resources[0]);
+      resources[5] = FakeResource.new("/1/5/6/e.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 60, "Sub page A", resources[0]);
+      resources[0].add_children [resources[1], resources[2], resources[3], resources[4], resources[5]]
 
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
-                            url: "/index.html",
+                            url: "/1/2/3/index.html",
+                            path: "/1/2/3/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
@@ -152,18 +156,42 @@ describe GovukTechDocs::TableOfContents::Helpers do
 <li><a href="/index.html"><span>Index</span></a>
 <ul>
   <li>
-    <a href="/a.html"><span>Heading one</span></a>
+    <a href="/1/2/a.html"><span>Heading one</span></a>
     <ul>
       <li>
-        <a href="/a.html#heading-two"><span>Heading two</span></a>
+        <a href="/1/2/a.html#heading-two"><span>Heading two</span></a>
       </li>
     </ul>
   </li>
   <li>
-    <a href="/b.html"><span>Heading one</span></a>
+    <a href="/1/2/3/b.html"><span>Heading one</span></a>
     <ul>
       <li>
-        <a href="/b.html#heading-two"><span>Heading two</span></a>
+        <a href="/1/2/3/b.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/2/3/4/c.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/2/3/4/c.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/5/d.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/5/d.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="/1/5/6/e.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="/1/5/6/e.html#heading-two"><span>Heading two</span></a>
       </li>
     </ul>
   </li>
@@ -175,7 +203,86 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
     end
 
-    it "builds a table of contents from several page resources with a custom http prefix ocnfigured" do
+    it "builds a table of contents using relative links from several page resources" do
+      resources = []
+      resources[0] = FakeResource.new("/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
+      resources[1] = FakeResource.new("/1/2/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 20, "Sub page A", resources[0]);
+      resources[2] = FakeResource.new("/1/2/3/b.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 30, "Sub page A", resources[0]);
+      resources[3] = FakeResource.new("/1/2/3/4/c.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 40, "Sub page B", resources[0]);
+      resources[4] = FakeResource.new("/1/5/d.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 50, "Sub page A", resources[0]);
+      resources[5] = FakeResource.new("/1/5/6/e.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 60, "Sub page A", resources[0]);
+      resources[0].add_children [resources[1], resources[2], resources[3], resources[4], resources[5]]
+
+      current_page = double("current_page",
+                            data: double("page_frontmatter", description: "The description.", title: "The Title"),
+                            url: "/1/2/3/index.html",
+                            path: "/1/2/3/index.html",
+                            metadata: { locals: {} })
+
+      current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
+
+      config = {
+        http_prefix: "/",
+        relative_links: true,
+        tech_docs: {
+          max_toc_heading_level: 3,
+        },
+      }
+
+      expected_multi_page_table_of_contents = %{
+<ul>
+<li><a href="../../../index.html"><span>Index</span></a>
+<ul>
+  <li>
+    <a href="../../../1/2/a.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/a.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/2/3/b.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/3/b.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/2/3/4/c.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/2/3/4/c.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/5/d.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/5/d.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="../../../1/5/6/e.html"><span>Heading one</span></a>
+    <ul>
+      <li>
+        <a href="../../../1/5/6/e.html#heading-two"><span>Heading two</span></a>
+      </li>
+    </ul>
+  </li>
+</ul>
+</li>
+</ul>
+      }
+
+      expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
+    end
+
+    #TODO: Assess whether this test is still relevant given that we are now generating relative links.
+    it "builds a table of contents from several page resources with a custom http prefix configured" do
       resources = []
       resources[0] = FakeResource.new("/prefix/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Index");
       resources[1] = FakeResource.new("/prefix/a.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>', 10, "Sub page A", resources[0]);
@@ -185,6 +292,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
                             url: "/prefix/index.html",
+                            path: "/prefix/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';
@@ -231,6 +339,7 @@ describe GovukTechDocs::TableOfContents::Helpers do
       current_page = double("current_page",
                             data: double("page_frontmatter", description: "The description.", title: "The Title"),
                             url: "/index.html",
+                            path: "/index.html",
                             metadata: { locals: {} })
 
       current_page_html = '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>';


### PR DESCRIPTION
## What are you trying to do?

Make it possible to generate a fully working site, in which all intra-site links (i.e. links within the site, between pages, to assets etc) are generated as relative links, so that the site can be deployed at a path other than "/".

## Identifying a user need

At HMRC we use the tech-docs-template to deploy multiple docs-as-code sites at different paths on a single domain e.g.

```
docs.tax.service.gov.uk/site-1
docs.tax.service.gov.uk/site-2
docs.tax.service.gov.uk/site-3
... etc
```

Without these changes the site links do not function correctly.

## Is it a change or a bug fix?

Change.

## What’s changed?

The changes are driven via standard Middleman configuration:

```yaml
set :relative_links, true
activate :relative_assets
```

When enabled, the above configuration causes the following changes to happen:

1. The Table of Contents is generated using relative links (824116a9f3be15c9641e9047d638dca84ff5ed85)
2. The Table of Contents expands, collapsed and is highlighted using relative links (a2dde29337afcb84c7bd19ac800b0cf074072af7)
3. The search function works using relative links (a2dde29337afcb84c7bd19ac800b0cf074072af7)
4. The `/api/pages.json` endpoint returns relative links, such that the `tech-docs-monitor` can correctly generate page URLs when raising Slack notifications (16396e70a8db310ccbaca8121fbe9eb2bdb484bc). This requires a companion `tech-docs-monitor` change for which the PR is [here](https://github.com/alphagov/tech-docs-monitor/pull/37).

### Testing

We are testing these changes at HMRC at the moment and haven't yet observed anything which has broken as a result of the changes. We don't believe the changes cause any regressions when building sites in the normal way using absolute links. However we'd be grateful for any additional testing people can do.


