### PR TITLE
Make GOV.UK Frontend assets paths work with http prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+You no longer need to change the Sass variable govuk-assets-path when using a http prefix; the tech docs gem will add the prefix for you.
+
+- [#292: Make GOV.UK Frontend assets path work with http prefix](https://github.com/alphagov/tech-docs-gem/pull/292)
+
 ## 3.2.1
 
 ### Fixes

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -1,4 +1,20 @@
-$govuk-assets-path: "/assets/govuk/assets/" !default;
+// Set $govuk-assets-path so that $govuk-images-path and $govuk-fonts-path
+// (used below, but set in govuk/base) are correct.
+$govuk-assets-path: "/assets/govuk/assets/";
+
+// Use Sprockets' asset url helpers to add the http prefix if present.
+// GOV.UK Frontend provides hooks for us to define the url lookup functions,
+// see https://frontend.design-system.service.gov.uk/sass-api-reference/
+@function tech-docs-image-url-function($filename) {
+  @return image-url($govuk-images-path + $filename);
+}
+
+@function tech-docs-font-url-function($filename) {
+  @return font-url($govuk-fonts-path + $filename);
+}
+
+$govuk-font-url-function: "tech-docs-font-url-function";
+$govuk-image-url-function: "tech-docs-image-url-function";
 
 // Include only the bits of GOV.UK Frontend we need
 $govuk-new-link-styles: true;

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -24,12 +24,24 @@ require "govuk_tech_docs/warning_text_extension"
 require "govuk_tech_docs/api_reference/api_reference_extension"
 
 module GovukTechDocs
+  class GovukTechDocsExtension < Middleman::Extension
+    def after_configuration
+      if app.config[:govuk_assets_path]
+        warn "Warning: setting govuk_assets_path in config.rb is no longer necessary, and will have no effect."
+      end
+    end
+  end
+
+  ::Middleman::Extensions.register(:govuk_tech_docs, GovukTechDocsExtension)
+
   # Configure the tech docs template
   #
   # @param options [Hash]
   # @option options [Hash] livereload Options to pass to the `livereload`
   #   extension. Hash with symbols as keys.
   def self.configure(context, options = {})
+    context.activate :govuk_tech_docs
+
     context.activate :sprockets
 
     context.sprockets.append_path File.join(__dir__, "../node_modules/govuk-frontend/")


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

You no longer need to change the Sass variable `govuk-assets-path` when using a http prefix; the tech docs gem will add the prefix for you.

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->

Users who want to deploy their tech docs to GitHub pages need to handle an additional path prefix to all URLs; they may want to use the `http_prefix` setting for this. PR #197 added this http prefix to all assets from the tech docs gem, but required the user to also override `govuk-assets-path` themselves so that assets from GOV.UK Frontend had the correct path. This PR should mean that this additional step is no longer required, making configuration easier for users.