### PR TITLE
Fix Nokogiri  `Node.new` deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+Deprecation warnings from Nokogiri addressed when rendering markdown tables
+
 ## 3.2.0
 
 ### New features

--- a/example/source/code.html.md
+++ b/example/source/code.html.md
@@ -10,32 +10,9 @@ A paragraph with a `code` element within it.
 
 An example of a table with a `code` element within it.
 
-<div class="table-container">
-  <table>
-    <thead>
-      <tr>
-        <th style="text-align:left">httpResult</th>
-        <th style="text-align:left">Message</th>
-        <th style="text-align:left">How to fix</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td style="text-align:left"><code>400</code></td>
-        <td style="text-align:left">
-          <code>[{</code>
-          <br />
-          <code>"error": "BadRequestError",</code>
-          <br />
-          <code>"message": "Can't send to this recipient using a team-only API key"</code>
-          <br />
-          <code>]}</code>
-        </td>
-        <td style="text-align:left">Use the correct type of API key</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+| httpResult | Message | How to fix |
+| -          | -       | -          |
+| `400`      | `[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}` | Use the correct type of API key |
 
 An example of a code block with a long line length
 

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -69,7 +69,7 @@ module GovukTechDocs
         first_child.content = leading_text.sub(/# */, "")
       end
 
-      tr = Nokogiri::XML::Node.new "tr", fragment
+      tr = Nokogiri::XML::Node.new "tr", fragment.document
       tr.children = fragment.children
 
       tr.to_html
@@ -95,9 +95,9 @@ module GovukTechDocs
         # be `defined?`, so we can jump straight to rendering HTML ourselves.
 
         fragment = Nokogiri::HTML::DocumentFragment.parse("")
-        pre = Nokogiri::XML::Node.new "pre", fragment
+        pre = Nokogiri::XML::Node.new "pre", fragment.document
         pre["tabindex"] = "0"
-        code = Nokogiri::XML::Node.new "code", fragment
+        code = Nokogiri::XML::Node.new "code", fragment.document
         code["class"] = lang
         code.content = text
         pre.add_child code


### PR DESCRIPTION
Fixes https://github.com/alphagov/tech-docs-gem/issues/295

<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

Deprecation warnings from Nokogiri addressed when rendering markdown tables

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->


## Identifying a user need

Not spamming my logs pls and thank you

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->

cc @lfdebrux