### PR TITLE
Documenting enum schemas

### DIFF
--- a/example/source/pets.yml
+++ b/example/source/pets.yml
@@ -93,10 +93,19 @@ components:
           type: string
         tag:
           type: string
+        status:
+          $ref: "#/components/schemas/PetStatus"
     Pets:
       type: array
       items:
         $ref: "#/components/schemas/Pet"
+    PetStatus:
+      type: string
+      description: pet status in the store
+      enum:
+        - pending
+        - available
+        - sold
     Error:
       required:
         - code

--- a/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/schema.html.erb
@@ -27,3 +27,11 @@
 </tbody>
 </table>
 <% end %>
+<% if schema.enum %>
+<p>This schema can be any one of the following <%= schema.type.pluralize %>:</p>
+<ul class='<%= id.parameterize %>-enum'>
+<% schema.enum.sort.each do |value| %>
+<li><%= value %></li>
+<% end %>
+</ul>
+<% end %>

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -79,5 +79,26 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
       expect(rendered).to have_css("div#server-list>p>strong", text: "Development")
       expect(rendered).to have_css("div#server-list>p>strong>p>em", text: "Development")
     end
+
+    it "renders a schema" do
+      @spec["components"] = {
+        "schemas": {
+          "Pet": {
+            "properties": {
+              "id": { "type": "integer", "format": "int64" },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = render.api_full(document.info, document.servers)
+
+      rendered = Capybara::Node::Simple.new(rendered)
+      expect(rendered).to have_css("h2#schemas", text: "Schemas")
+      expect(rendered).to have_css("h3#schema-pet", text: "Pet")
+      expect(rendered).to have_css("table.schema-pet", text: "id")
+    end
   end
 end

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -100,5 +100,26 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
       expect(rendered).to have_css("h3#schema-pet", text: "Pet")
       expect(rendered).to have_css("table.schema-pet", text: "id")
     end
+
+    it "renders an enum schema" do
+      @spec["components"] = {
+        "schemas": {
+          "Pet": {
+            "type": "string",
+            "enum": %w[pending available sold],
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = render.api_full(document.info, document.servers)
+
+      rendered = Capybara::Node::Simple.new(rendered)
+      expect(rendered).to have_css("h3#schema-pet", text: "Pet")
+      expect(rendered).to have_css(".schema-pet-enum", text: "pending")
+      expect(rendered).to have_css(".schema-pet-enum", text: "available")
+      expect(rendered).to have_css(".schema-pet-enum", text: "sold")
+    end
   end
 end


### PR DESCRIPTION
## What’s changed

The tech docs template doesn't appear to allow documenting [enums in schemas](https://swagger.io/docs/specification/data-models/enums/).

This change adds basic support for this feature:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/23801/175347257-8d378aa5-4a88-40e7-94a6-54d837a39e63.png">

## Identifying a user need

Within DfE, we have a [need to display enums when generating the API docs for the Qualified Teachers API](https://github.com/DFE-Digital/qualified-teachers-api/blob/66c6d4601adf1f650cd649f7d571e77a3993a831/docs/api-specs/v2.json#L469-L486).