### PR TITLE
Bugfix: only add link if an ID attribute is present

### DIFF
--- a/lib/assets/javascripts/_modules/anchored-headings.js
+++ b/lib/assets/javascripts/_modules/anchored-headings.js
@@ -9,10 +9,12 @@
 
     function injectAnchor () {
       var $this = $(this)
-      $this.addClass('anchored-heading')
-      $this.prepend(
-        '<a href="#' + $this.attr('id') + '" class="anchored-heading__icon" aria-hidden="true" tabindex="-1"></a>'
-      )
+      if ($this.attr('id')) {        
+        $this.addClass('anchored-heading')
+        $this.prepend(
+          '<a href="#' + $this.attr('id') + '" class="anchored-heading__icon" aria-hidden="true" tabindex="-1"></a>'
+        )
+      }
     }
   }
 })(jQuery, window.GOVUK.Modules)


### PR DESCRIPTION
This fixes a bug experienced downstream on the [Design in the Department of Education](https://design.education.gov.uk) website, where a link was being injected with the href of `#undefined` due to a missing `id` attribute on the `<h2>` element.

This could be fixed by auto-generating an ID attribute if one is missing, but perhaps a safer alternative would be to not inject the link at all in these circumstances. This would also let services opt-out of adding the link on specific headings where it doesn’t make sense to do so, such on a homepage where the heading already contains a link to another page.

See https://github.com/DFE-Digital/design-in-dfe/pull/11

<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->


## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->
