### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,7 +422,7 @@ which item is selected in the navigation.
 More info:
 
 - https://github.com/alphagov/tech-docs-gem/pull/19
-- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#parent
+- https://github.com/alphagov/tech-docs-gem/blob/main/docs/frontmatter.md#parent
 
 ## 1.2.0
 
@@ -434,15 +434,15 @@ You can use this when you change a page URL.
 
 More info:
 
-- https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#redirects
-- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#old_paths
+- https://github.com/alphagov/tech-docs-gem/blob/main/docs/configuration.md#redirects
+- https://github.com/alphagov/tech-docs-gem/blob/main/docs/frontmatter.md#old_paths
 
 ### New feature: contribution banner
 
 You can now show a block at the bottom of the page that links to
 the page source on GitHub, so readers can easily contribute back to the documentation.
 
-https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#show_contribution_banner
+https://github.com/alphagov/tech-docs-gem/blob/main/docs/configuration.md#show_contribution_banner
 
 ### New feature: page review system
 
@@ -450,8 +450,8 @@ An optional page review system to make sure documentation stays up to date.
 
 More info:
 
-- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#last_reviewed_on
-- https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md#owner_slack
+- https://github.com/alphagov/tech-docs-gem/blob/main/docs/frontmatter.md#last_reviewed_on
+- https://github.com/alphagov/tech-docs-gem/blob/main/docs/frontmatter.md#owner_slack
 
 
 ### Better meta tags
@@ -463,7 +463,7 @@ Pages now include better meta tags for search engines, Twitter, Facebook and Sla
 You can now specify `google_site_verification` in tech-docs.yml. You can use
 this to verify your site in Google Webmaster tools.
 
-https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md#google_site_verification
+https://github.com/alphagov/tech-docs-gem/blob/main/docs/configuration.md#google_site_verification
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Find out how to [contribute](https://tdt-documentation.london.cloudapps.digital/
 
 This gem uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), part of the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-We use `npm` to download the govuk-frontend package. To update to a new version, change the version in the [package.json file](blob/main/package.json) and run `npm update`.
+We use `npm` to download the govuk-frontend package. To update to a new version, change the version in the [package.json file](package.json) and run `npm update`.
 
 ## Developing locally
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Find out how to [contribute](https://tdt-documentation.london.cloudapps.digital/
 
 This gem uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend), part of the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-We use `npm` to download the govuk-frontend package. To update to a new version, change the version in the [package.json file](blob/master/package.json) and run `npm update`.
+We use `npm` to download the govuk-frontend package. To update to a new version, change the version in the [package.json file](blob/main/package.json) and run `npm update`.
 
 ## Developing locally
 
@@ -96,7 +96,7 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 [tdt-docs]: https://tdt-documentation.london.cloudapps.digital
 [tdt-template]: https://github.com/alphagov/tech-docs-template
-[tdt-readme]: https://github.com/alphagov/tech-docs-template/blob/master/README.md
+[tdt-readme]: https://github.com/alphagov/tech-docs-template/blob/main/README.md
 [mmt]: https://middlemanapp.com/advanced/project_templates/
 
 [jas]: https://jasmine.github.io/

--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -39,7 +39,7 @@ module GovukTechDocs
     end
 
     def repo_branch
-      config[:tech_docs][:github_branch] || "master"
+      config[:tech_docs][:github_branch] || "master" # TODO: change this to 'main' in a future breaking release
     end
 
   private


### PR DESCRIPTION
Update links to use new name.

Also leave a note to change the default branch name for the contribution banner link; we can't change this without it being a breaking change for users.