### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 concurrency: rubygems


### PR DESCRIPTION
We've renamed the default branch to main, fix the GitHub Actions workflows to match.

This was missed in #306