### PR TITLE
Configure Slack link for review fragments

### DIFF
--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -52,4 +52,5 @@ api_path: source/pets.yml
 
 # Optional global settings for the page review process
 owner_slack_workspace: gds
-default_owner_slack: '#2nd-line'
+default_owner_slack: '#2nd-line'    # right click on channel/DM in Slack > Copy > Copy name
+default_owner_slack_id: 'C02DYEB3J' # right click on channel/DM in Slack > Copy > Copy link

--- a/lib/govuk_tech_docs/page_review.rb
+++ b/lib/govuk_tech_docs/page_review.rb
@@ -31,8 +31,6 @@ module GovukTechDocs
     def owner_slack_url
       return "" unless owner_slack_workspace
 
-      # Slack URLs don't have the # (channels) or @ (usernames)
-      slack_identifier = owner_slack.to_s.delete("#").delete("@")
       "https://#{owner_slack_workspace}.slack.com/messages/#{slack_identifier}"
     end
 
@@ -46,8 +44,19 @@ module GovukTechDocs
 
   private
 
+    def slack_identifier
+      identifier = page.data.owner_slack_id || default_owner_slack_id || owner_slack
+
+      # Slack URLs don't have the # (channels) or @ (usernames)
+      identifier.to_s.delete("#").delete("@")
+    end
+
     def default_owner_slack
       @config[:tech_docs][:default_owner_slack]
+    end
+
+    def default_owner_slack_id
+      @config[:tech_docs][:default_owner_slack_id]
     end
 
     def owner_slack_workspace

--- a/spec/govuk_tech_docs/page_review_spec.rb
+++ b/spec/govuk_tech_docs/page_review_spec.rb
@@ -20,22 +20,34 @@ RSpec.describe GovukTechDocs::PageReview do
       expect(review_by.owner_slack_url).to be_empty
     end
 
-    it "links to Slack usernames" do
-      review_by = described_class.new(
-        double(data: double(owner_slack: "@foo")),
-        tech_docs: { owner_slack_workspace: "govuk" },
+    it "links to Slack usernames without the @ prefix" do
+      config = { owner_slack_workspace: "govuk", default_owner_slack: "@from.config" }
+      page_review_by = described_class.new(
+        double(data: double(owner_slack: "@from.page")),
+        tech_docs: config,
+      )
+      config_review_by = described_class.new(
+        double(data: double(owner_slack: nil)),
+        tech_docs: config,
       )
 
-      expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")
+      expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from.page")
+      expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from.config")
     end
 
-    it "links to Slack channels" do
-      review_by = described_class.new(
-        double(data: double(owner_slack: "#foo")),
-        tech_docs: { owner_slack_workspace: "govuk" },
+    it "links to Slack channels without the # prefix" do
+      config = { owner_slack_workspace: "govuk", default_owner_slack: "#from_config" }
+      page_review_by = described_class.new(
+        double(data: double(owner_slack: "#from_page")),
+        tech_docs: config,
+      )
+      config_review_by = described_class.new(
+        double(data: double(owner_slack: nil)),
+        tech_docs: config,
       )
 
-      expect(review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/foo")
+      expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_page")
+      expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_config")
     end
   end
 

--- a/spec/govuk_tech_docs/page_review_spec.rb
+++ b/spec/govuk_tech_docs/page_review_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe GovukTechDocs::PageReview do
     it "links to Slack usernames without the @ prefix" do
       config = { owner_slack_workspace: "govuk", default_owner_slack: "@from.config" }
       page_review_by = described_class.new(
-        double(data: double(owner_slack: "@from.page")),
+        double(data: double(owner_slack: "@from.page", owner_slack_id: nil)),
         tech_docs: config,
       )
       config_review_by = described_class.new(
-        double(data: double(owner_slack: nil)),
+        double(data: double(owner_slack: nil, owner_slack_id: nil)),
         tech_docs: config,
       )
 
@@ -40,11 +40,11 @@ RSpec.describe GovukTechDocs::PageReview do
     it "links to Slack channels without the # prefix" do
       config = { owner_slack_workspace: "govuk", default_owner_slack: "#from_config" }
       page_review_by = described_class.new(
-        double(data: double(owner_slack: "#from_page")),
+        double(data: double(owner_slack: "#from_page", owner_slack_id: nil)),
         tech_docs: config,
       )
       config_review_by = described_class.new(
-        double(data: double(owner_slack: nil)),
+        double(data: double(owner_slack: nil, owner_slack_id: nil)),
         tech_docs: config,
       )
 
@@ -52,6 +52,23 @@ RSpec.describe GovukTechDocs::PageReview do
       expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_page")
       expect(config_review_by.owner_slack).to eql("#from_config")
       expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_config")
+    end
+
+    it "links to Slack identifiers with the given label" do
+      config = { owner_slack_workspace: "govuk", default_owner_slack: "#from_config", default_owner_slack_id: "0CONFIG" }
+      page_review_by = described_class.new(
+        double(data: double(owner_slack: "#from_page", owner_slack_id: "0PAGE")),
+        tech_docs: config,
+      )
+      config_review_by = described_class.new(
+        double(data: double(owner_slack: nil, owner_slack_id: nil)),
+        tech_docs: config,
+      )
+
+      expect(page_review_by.owner_slack).to eql("#from_page")
+      expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/0PAGE")
+      expect(config_review_by.owner_slack).to eql("#from_config")
+      expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/0CONFIG")
     end
   end
 

--- a/spec/govuk_tech_docs/page_review_spec.rb
+++ b/spec/govuk_tech_docs/page_review_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe GovukTechDocs::PageReview do
         tech_docs: config,
       )
 
+      expect(page_review_by.owner_slack).to eql("@from.page")
       expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from.page")
+      expect(config_review_by.owner_slack).to eql("@from.config")
       expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from.config")
     end
 
@@ -46,7 +48,9 @@ RSpec.describe GovukTechDocs::PageReview do
         tech_docs: config,
       )
 
+      expect(page_review_by.owner_slack).to eql("#from_page")
       expect(page_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_page")
+      expect(config_review_by.owner_slack).to eql("#from_config")
       expect(config_review_by.owner_slack_url).to eql("https://govuk.slack.com/messages/from_config")
     end
   end


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

This pull request adds the possibility of configuring the "link" behind the Slack name.

This addition is optional and backwards compatible.

🙋 Please review commit-by-commit: I've added a couple of test cases before the changes.

## Identifying a user need

For my use case, https://mojds.slack.com/messages/interventions-dev does not work; it will default to the default channel instead.

I have to use the ID: https://mojds.slack.com/messages/C01DYKJUKDX 

## Configuration changes

(These all work with page data as well.)

Before:

    owner_slack_workspace: mojds
    default_owner_slack: "#interventions-dev"

produces

    <a href="https://mojds.slack.com/messages/interventions-dev">#interventions-dev</a>

(which does not work in our Slack instance)

---

With the new option:

    owner_slack_workspace: mojds
    default_owner_slack: "#interventions-dev"
    default_owner_slack_id: "C01DYKJUKDX"

produces

    <a href="https://mojds.slack.com/messages/C01DYKJUKDX">#interventions-dev</a>
