### PR TITLE
Bump govuk-frontend to 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
-      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard"
   },
   "dependencies": {
-    "govuk-frontend": "^4.0.0"
+    "govuk-frontend": "^4.4.1"
   },
   "devDependencies": {
     "standard": "^14.3.4"


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->
Updates the version of `govuk-frontend` to its latest release, 4.4.1

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->
This brings up the changes from 4.0.0 to 4.4.1, especially [an accessibility fix for focus styles on the latest version of Chrome](https://github.com/alphagov/govuk-frontend/pull/3108).