### PR TITLE
Add ability to specify a repository directory for the contribution URL

### DIFF
--- a/lib/govuk_tech_docs/contribution_banner.rb
+++ b/lib/govuk_tech_docs/contribution_banner.rb
@@ -58,7 +58,12 @@ module GovukTechDocs
 
     # As the last fallback link to the source file in this repository.
     def source_from_file
-      "#{repo_url}/blob/#{repo_branch}/source/#{current_page.file_descriptor[:relative_path]}"
+      repo_directory = config[:tech_docs][:repo_directory]
+      if repo_directory.nil?
+        "#{repo_url}/blob/#{repo_branch}/source/#{current_page.file_descriptor[:relative_path]}"
+      else
+        "#{repo_url}/blob/#{repo_branch}/#{repo_directory}/source/#{current_page.file_descriptor[:relative_path]}"
+      end
     end
 
     def locals


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

Allows user to specify a `repo_directory` in the config file, useful if running docs from a folder within a repository, like the [Ministry of Justice's Data Platform](https://github.com/ministryofjustice/data-platform/tree/main/docs)

### Example

```yaml
repo_directory: docs
```

## Identifying a user need

I am contributing this back from [our forked version](https://github.com/ministryofjustice/tech-docs-gem)
