### PR TITLE
Specify Ruby version for publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,14 +24,14 @@ jobs:
         id: gem_version
         run: |
           gem_version=$(ruby -r rubygems -e "puts Gem::Specification::load('govuk_tech_docs.gemspec').version")
-          echo "::set-output name=gem_version::$gem_version"
+          echo "gem_version=$gem_version" >> "$GITHUB_OUTPUT"
 
           if git fetch origin "refs/tags/v$gem_version" >/dev/null 2>&1
           then
             echo "Tag 'v$gem_version' already exists"
-            echo "::set-output name=new_version::false"
+            echo "new_version=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=new_version::true"
+            echo "new_version=true" >> "$GITHUB_OUTPUT"
           fi
 
   deploy:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
       go: ${{ steps.gem_version.outputs.new_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
 
@@ -44,7 +44,7 @@ jobs:
     if: ${{ needs.pre.outputs.go == 'true' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3'
 
       - name: Check if new version to release
         id: gem_version
@@ -53,6 +55,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3'
           bundler-cache: true
 
       - name: Publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         ruby: ['2.7', '3.2']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR fixes the publish workflow.

The ruby/setup-ruby action needs a version of Ruby specified to work. Previously it was reading the `.ruby-version` file, however we removed that in commit 2aa58c. We could restore that file, but because `ruby-install` doesn't support loose version specifiers, we'd have to keep it maintained. Instead we just tell the action to install the latest version of Ruby 3.