### PR TITLE
Update rubocop-govuk to v4.13.0

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jasmine", "~> 3.5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9.0"
-  spec.add_development_dependency "rubocop-govuk", "~> 4.10.0"
+  spec.add_development_dependency "rubocop-govuk", "~> 4.13.0"
 end


### PR DESCRIPTION
## What’s changed

Depends on: https://github.com/alphagov/tech-docs-gem/pull/339
Bump rubocop-govuk to v4.13.0

## Identifying a user need

Dependency updates need to happen otherwise folks will start forking this repo and it's relevance declines.
