### PR TITLE
Shift required_ruby_version to v3.1.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3'
+          ruby-version: "3"
 
       - name: Check if new version to release
         id: gem_version
@@ -40,7 +40,7 @@ jobs:
     name: Publish Ruby Gem
     environment: rubygems
     permissions:
-      contents: write  # needed to be able to tag the release
+      contents: write # needed to be able to tag the release
     runs-on: ubuntu-latest
     needs: pre
     if: ${{ needs.pre.outputs.go == 'true' }}
@@ -50,12 +50,12 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3'
+          ruby-version: "3"
           bundler-cache: true
 
       - name: Publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,15 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.7', '3.2']
+        ruby: ["3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Breaking change: Update minimum ruby requirements to 3.1.4
+
 ## 3.4.0
 
 ### New features

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "autoprefixer-rails", "~> 10.2"
   spec.add_dependency "chronic", "~> 0.10.2"


### PR DESCRIPTION
## What’s changed

Minimum supported ruby is now 3.1.4

Breaking change:
2.7x was end of support 31 Mar 2023
We'll run into dependency issues (expectations having moved up) if we don't upgrade.

Let's move the testing to target the 3x series, but enforce 3 as a new minimum.

## Identifying a user need

We need to keep our dependencies up to date, or this repo should be archived
