### PR TITLE
Bump govuk-frontend to v4.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "tech-docs-gem",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "^4.4.1"
+        "govuk-frontend": "^4.8.0"
       },
       "devDependencies": {
         "standard": "^14.3.4"
@@ -1053,9 +1053,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -3508,9 +3508,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard"
   },
   "dependencies": {
-    "govuk-frontend": "^4.4.1"
+    "govuk-frontend": "^4.8.0"
   },
   "devDependencies": {
     "standard": "^14.3.4"


### PR DESCRIPTION
Resolves #337 

This release includes the ability to update the crown logo. You must do this between 19 February and 1 March 2024. Note that many docs repositories use this gem to set the version of the design system used.

We will need to carefully consider when to merge this and roll an update as it comes with immediate operational impacts around use of favicons.

As we cannot use the Nunjuks template here as a feature flag, when we are ready to enable the tudor crown we will need to follow the upgrading guidance here:

https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0

Note that a v5.1 of the design system has also been published. I suggest we get this merged then consider a broader set of upgrades as part of any next major release to this gem

## What’s changed

Bumps [govuk-frontend](https://www.npmjs.com/package/govuk-frontend) from v4.4.1 to [v4.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0)


## Identifying a user need

A required upgrade to ensure all instances of the Tech Docs Template are able to update to the Tudor Crown from the 19th Febuary.

This is a requirement before the 1st March 2024. 
