### PR TITLE
Dependency - Redcarpet 3.5.1 -> 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Updates to dependencies including:
+
+- Redcarpet to v3.6.0, removing warnings that appear in Tech Docs sites running Ruby 3.2+
+
 ## 3.5.0
 
 ### New features

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-syntax", "~> 3.2.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
-  spec.add_dependency "redcarpet", "~> 3.5.1"
+  spec.add_dependency "redcarpet", "~> 3.6.0"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"


### PR DESCRIPTION
## What’s changed

Updates to dependencies including:

- Redcarpet to v3.6.0, removing warnings that appear in Tech Docs sites running Ruby 3.2+