### PR TITLE
Drop support for end-of-life Ruby versions + update dependencies.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,9 @@ jobs:
       go: ${{ steps.gem_version.outputs.new_version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -43,12 +45,14 @@ jobs:
       contents: write  # needed to be able to tag the release
     runs-on: ubuntu-latest
     needs: pre
-    if: ${{ needs.pre.outputs.go == 'true' }}
+    if: needs.pre.outputs.go == 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -9,12 +14,14 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.7', '3.2']
+        ruby: ['3.1', '3.2', '3.3']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
     - config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
 
 Layout/HeredocIndentation:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- BREAKING: drop support for end-of-life Ruby versions 2.7 and 3.0. The minimum Ruby version is now 3.1.
+- Update gem dependencies.
+- Declare some missing indirect dependencies to prepare for Ruby 3.4. This also resolves some warnings about this at build time.
+
 ## 3.5.0
 
 ### New features

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -33,26 +33,26 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "autoprefixer-rails", "~> 10.2"
   spec.add_dependency "chronic", "~> 0.10.2"
-  spec.add_dependency "haml", "< 6.0.0"
+  spec.add_dependency "haml", "~> 6.0"
   spec.add_dependency "middleman", "~> 4.0"
-  spec.add_dependency "middleman-autoprefixer", "~> 2.10.0"
-  spec.add_dependency "middleman-compass", ">= 4.0.0"
+  spec.add_dependency "middleman-autoprefixer", "~> 2.10"
+  spec.add_dependency "middleman-compass", "~> 4.0"
   spec.add_dependency "middleman-livereload"
   spec.add_dependency "middleman-search-gds"
-  spec.add_dependency "middleman-sprockets", "~> 4.0.0"
-  spec.add_dependency "middleman-syntax", "~> 3.2.0"
+  spec.add_dependency "middleman-sprockets", "~> 4.1"
+  spec.add_dependency "middleman-syntax", "~> 3.4"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
-  spec.add_dependency "redcarpet", "~> 3.5.1"
+  spec.add_dependency "redcarpet", "~> 3.6"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"
-  spec.add_development_dependency "jasmine", "~> 3.5.0"
+  spec.add_development_dependency "jasmine", "~> 3.5"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.9.0"
-  spec.add_development_dependency "rubocop-govuk", "~> 4.10.0"
+  spec.add_development_dependency "rspec", "~> 3.9"
+  spec.add_development_dependency "rubocop-govuk", "~> 4.10"
 end

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -36,7 +36,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "autoprefixer-rails", "~> 10.2"
+  spec.add_dependency "base64" # TODO: remove once middleman-sprockets declares this itself.
+  spec.add_dependency "bigdecimal" # TODO: remove once activesupport declares this itself.
   spec.add_dependency "chronic", "~> 0.10.2"
+  spec.add_dependency "csv" # TODO: remove once tilt declares this itself.
   spec.add_dependency "haml", "~> 6.0"
   spec.add_dependency "middleman", "~> 4.0"
   spec.add_dependency "middleman-autoprefixer", "~> 2.10"
@@ -45,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-search-gds"
   spec.add_dependency "middleman-sprockets", "~> 4.0.0"
   spec.add_dependency "middleman-syntax", "~> 3.4"
+  spec.add_dependency "mutex_m" # TODO: remove once activesupport declares this itself.
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
   spec.add_dependency "redcarpet", "~> 3.6"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-compass", "~> 4.0"
   spec.add_dependency "middleman-livereload"
   spec.add_dependency "middleman-search-gds"
-  spec.add_dependency "middleman-sprockets", "~> 4.1"
+  spec.add_dependency "middleman-sprockets", "~> 4.0.0"
   spec.add_dependency "middleman-syntax", "~> 3.4"
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -44,7 +44,7 @@ module GovukTechDocs
                 renderer: TechDocsHTMLRenderer.new(
                   with_toc_data: true,
                   api: true,
-                  context: context,
+                  context:,
                 ),
                 fenced_code_blocks: true,
                 tables: true,

--- a/lib/govuk_tech_docs/redirects.rb
+++ b/lib/govuk_tech_docs/redirects.rb
@@ -1,6 +1,6 @@
 module GovukTechDocs
   class Redirects
-    LEADING_SLASH = %r{\A/}.freeze
+    LEADING_SLASH = %r{\A/}
 
     def initialize(context)
       @context = context

--- a/lib/govuk_tech_docs/table_of_contents/heading_tree_builder.rb
+++ b/lib/govuk_tech_docs/table_of_contents/heading_tree_builder.rb
@@ -11,7 +11,7 @@ module GovukTechDocs
         @headings.each do |heading|
           move_to_depth(heading.size)
 
-          @pointer.children << HeadingTree.new(parent: @pointer, heading: heading)
+          @pointer.children << HeadingTree.new(parent: @pointer, heading:)
         end
 
         @tree

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -12,7 +12,7 @@ module GovukTechDocs
 
       def single_page_table_of_contents(html, url: "", max_level: nil)
         output = "<ul>\n"
-        output += list_items_from_headings(html, url: url, max_level: max_level)
+        output += list_items_from_headings(html, url:, max_level:)
         output += "</ul>\n"
 
         output
@@ -36,7 +36,7 @@ module GovukTechDocs
         end
 
         tree = HeadingTreeBuilder.new(headings).tree
-        HeadingTreeRenderer.new(tree, max_level: max_level).html
+        HeadingTreeRenderer.new(tree, max_level:).html
       end
 
       def render_page_tree(resources, current_page, config, current_page_html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2252,9 +2252,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2662,9 +2662,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2915,9 +2915,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -3889,9 +3889,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -3949,9 +3949,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -4385,9 +4385,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "shebang-command": {
@@ -4722,9 +4722,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrappy": {

--- a/spec/govuk_tech_docs/source_urls_spec.rb
+++ b/spec/govuk_tech_docs/source_urls_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GovukTechDocs::SourceUrls do
   def generate_config(repo, host)
     {
       tech_docs: {
-        host: host,
+        host:,
         github_repo: repo,
       },
     }
@@ -33,8 +33,8 @@ RSpec.describe GovukTechDocs::SourceUrls do
 
   def generate_current_page(title, url)
     OpenStruct.new(
-      data: OpenStruct.new(title: title),
-      url: url,
+      data: OpenStruct.new(title:),
+      url:,
     )
   end
 end

--- a/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
+++ b/spec/govuk_tech_docs/tech_docs_html_renderer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
   let(:app) { double("app") }
   let(:context) { double("context") }
   let(:processor) do
-    Redcarpet::Markdown.new(described_class.new(context: context), tables: true, fenced_code_blocks: true)
+    Redcarpet::Markdown.new(described_class.new(context:), tables: true, fenced_code_blocks: true)
   end
 
   before :each do
@@ -59,7 +59,7 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
 
     context "without syntax highlighting" do
       let(:processor) do
-        Redcarpet::Markdown.new(described_class.new(context: context), fenced_code_blocks: true)
+        Redcarpet::Markdown.new(described_class.new(context:), fenced_code_blocks: true)
       end
 
       it "sets tab index to 0" do
@@ -78,7 +78,7 @@ RSpec.describe GovukTechDocs::TechDocsHTMLRenderer do
         renderer_class = described_class.clone.tap do |c|
           c.send :include, Middleman::Syntax::RedcarpetCodeRenderer
         end
-        Redcarpet::Markdown.new(renderer_class.new(context: context), fenced_code_blocks: true)
+        Redcarpet::Markdown.new(renderer_class.new(context:), fenced_code_blocks: true)
       end
 
       it "sets tab index to 0" do


### PR DESCRIPTION
- Drop support for Ruby 2.7 and 3.0 per our [version policy](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility).
- Update (theoretically) vulnerable npm packages (`npm audit fix`).
- Update rubygems dependencies as far as compatible.
- Update GitHub Actions dependencies.
- Declare some missing transitive dependencies for forward compatibility with Ruby 3.4.

Someone with repo admin (or alphagov org admin) will need to update the repo's branch protection rules to fix the list of required checks.