### PR TITLE
Remove aria-hidden from search label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - BREAKING: drop support for end-of-life Ruby versions 2.7 and 3.0. The minimum Ruby version is now 3.1.
 - Update gem dependencies.
 - Declare some missing indirect dependencies to prepare for Ruby 3.4. This also resolves some warnings about this at build time.
+- Remove aria-hidden from search label to let assistive technologies see its accessible name
 
 ## 3.5.0
 

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -2,7 +2,7 @@
 <div class="search" data-module="search" data-path-to-site-root="<%= path_to_site_root config, current_page.path %>">
   <form action="https://www.google.co.uk/search" method="get" role="search" class="search__form govuk-!-margin-bottom-4">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
-    <label class="govuk-label search__label" for="search" aria-hidden="true">
+    <label class="govuk-label search__label" for="search">
       Search (via Google)
     </label>
     <input

--- a/lib/source/layouts/_search.erb
+++ b/lib/source/layouts/_search.erb
@@ -6,7 +6,7 @@
       Search (via Google)
     </label>
     <input
-      type="text"
+      type="search"
       id="search" name="q"
       class="govuk-input govuk-!-margin-bottom-0 search__input"
       aria-controls="search-results"


### PR DESCRIPTION
Hiding it with `aria-hidden` removes it from the
accessibilty tree, which also stops it labelling
the input textbox.

It also already has styles to hide it visually so
doesn't need it for that.

## What’s changed

Removed [aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) from the search label to prevent it being hidden from accessibility APIs, and so stopped from labelling the sibling textbox.

I also changed the search texbox to `type=search` because it is and because we do that on [www.gov.uk](https//www.gov.uk). I think `type=search` wasn't supported widely enough[^1] when these docs were created to be used originally but that's not the case now.

### Accessibility tree (in Chrome devtools) Before

<img width="578" alt="search_label_before" src="https://github.com/user-attachments/assets/809b66a0-4379-4213-bbad-e40293407594">

### Accessibility tree (in Chrome devtools) After

<img width="664" alt="search_label_after" src="https://github.com/user-attachments/assets/bd415feb-79c4-442a-af58-96c2177f6280">


## Identifying a user need

The use of `aria-hidden` here currently prevents the search textbox having an accessible name. For users of screen readers, that means it isn't announced when the textbox is in focus.

This was identified by running [the WAVE accessibility checker](https://wave.webaim.org/extension/) on the tdt-documentation app (which uses this gem).

## Notes for reviewers

I'm not sure what to add to the CHANGELOG because it already has unreleased changes. Happy to do whatever is advised.

[^1]: We used to support IE9, which didn't support it: https://caniuse.com/input-search