### PR TITLE
Use hidden attribute to show/hide expiry notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update gem dependencies.
 - Declare some missing indirect dependencies to prepare for Ruby 3.4. This also resolves some warnings about this at build time.
 - Remove aria-hidden from search label to let assistive technologies see its accessible name
+- Use hidden attribute to show/hide expiry notices instead of just CSS
 
 ## 3.5.0
 

--- a/lib/assets/javascripts/_modules/page-expiry.js
+++ b/lib/assets/javascripts/_modules/page-expiry.js
@@ -7,8 +7,8 @@
       var isExpired = Date.parse(rawDate) < new Date()
 
       if (isExpired) {
-        $element.find('.page-expiry--not-expired').hide(0)
-        $element.find('.page-expiry--expired').show(0)
+        $element.find('.page-expiry--not-expired').attr('hidden', '')
+        $element.find('.page-expiry--expired').removeAttr('hidden')
       }
     }
   }

--- a/lib/assets/stylesheets/modules/_page-review.scss
+++ b/lib/assets/stylesheets/modules/_page-review.scss
@@ -24,8 +24,6 @@
 }
 
 .page-expiry--expired {
-  display: none;
-
   padding: govuk-spacing(3);
   margin-top: govuk-spacing(9);
   border: govuk-spacing(1) solid $govuk-error-colour;

--- a/lib/source/layouts/_page_review.erb
+++ b/lib/source/layouts/_page_review.erb
@@ -12,7 +12,7 @@
     </div>
 
     <% if current_page_review.show_expiry? %>
-    <div class='page-expiry--expired'>
+    <div class='page-expiry--expired' hidden>
       This page was set to be reviewed before <%= format_date current_page_review.review_by %><% if current_page_review.owner_slack %>
        by the page owner <%= link_to current_page_review.owner_slack, current_page_review.owner_slack_url %><% end %>.
       This might mean the content is out of date.


### PR DESCRIPTION
This means the notice we want to hide on page load doesn't depend on CSS for that.

It also makes it much clearer in the page
semantics that the notices are hidden or not.

## What’s changed

The notices for telling users that the page content has expired or not are shown or hidden by the presence of the `hidden` attribute instead of by CSS.

## Identifying a user need

This means the inclusion of the expiry notices is not dependent on CSS to work.

Not strictly accessibility-focused but I have had it raised in the past (by an automated SiteImprove audit) that hiding things by CSS only is a problem and that `hidden` should be used instead.

## Notes for reviewers

I'm not sure what to add to the CHANGELOG because it already has unreleased changes. Happy to do whatever is advised.