### PR TITLE
Silence dart sass warnings using the sass-embedded gem

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openapi3_parser", "~> 0.9.0"
   spec.add_dependency "redcarpet", "~> 3.6"
   spec.add_dependency "terser", "~> 1.2.3"
-  spec.add_dependency "sassc-embedded", "~> 1.78.0"
+  spec.add_dependency "sass-embedded", "~> 1.78.0"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -11,7 +11,7 @@ require "nokogiri"
 require "chronic"
 require "active_support/all"
 require "terser"
-require "sassc-embedded"
+require "sass-embedded"
 
 require "govuk_tech_docs/redirects"
 require "govuk_tech_docs/table_of_contents/helpers"
@@ -52,7 +52,6 @@ module GovukTechDocs
                 tables: true,
                 no_intra_emphasis: true
 
-    # this doesnt seem to work
     context.set :sass, { output_style: "nested", quiet_deps: true }
 
     # Reload the browser automatically whenever files change


### PR DESCRIPTION
With this change, we are ensuring that Middleman is using Dart Sass via the sass-embedded gem, which is the one that uses the quiet_deps option.

