### PR TITLE
Only wrap images with alt text in hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You need to
 - Use hidden attribute to show/hide expiry notices instead of just CSS
 - Only use dialog role for table of contents when it behaves like one (accessibility fix)
 - Prevent interactive elements being obscured by sticky table of contents header
+- Only wrap images with alt text in hyperlinks
 
 ## 3.5.0
 

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -20,7 +20,7 @@ module GovukTechDocs
     end
 
     def image(link, title, alt_text)
-      if alt_text
+      if alt_text && !alt_text.strip.empty?
         %(<a href="#{link}" rel="noopener noreferrer">#{super}</a>)
       else
         super

--- a/lib/govuk_tech_docs/tech_docs_html_renderer.rb
+++ b/lib/govuk_tech_docs/tech_docs_html_renderer.rb
@@ -19,8 +19,12 @@ module GovukTechDocs
       %(<h#{level} id="#{anchor}">#{text}</h#{level}>\n)
     end
 
-    def image(link, *args)
-      %(<a href="#{link}" rel="noopener noreferrer">#{super}</a>)
+    def image(link, title, alt_text)
+      if alt_text
+        %(<a href="#{link}" rel="noopener noreferrer">#{super}</a>)
+      else
+        super
+      end
     end
 
     def table(header, body)


### PR DESCRIPTION
## What’s changed

This introduces a guard against images with no alt text, choosing to only wrap them in hyperlinks, the default behaviour now, when found.

My Ruby is basic at best but I looked at the method we're overwriting from [the Red Carpet HTML renderer](https://github.com/middleman/middleman/blob/f46306b29443111605dadb8f164ef210393db831/middleman-core/lib/middleman-core/renderers/redcarpet.rb#L74) and copied across its interface more exactly, to make it clear where the `alt_text` variable comes from.

The difference in what users see is minimal. The hyperlinks don't have any special styles, like `display: block` so nothing is different with how they are laid out on the page (both the `<a>` and `<img>` tags default to `display: inline`).

## Identifying a user need

When we wrap images in hyperlinks, we make the image's alt text their only content. If those images have no alt text, they are effectively empty links.

This means they have no accessible name if queried by an accessibility API:

https://w3c.github.io/html-aam/#img-element-accessible-name-computation

...so it'll be up to the screen reader talking to the accessibility API to guess. By testing with the Voiceover, NVDA and JAWs, I screen reders, I found this ends up being the file name, which can't be relied on to explain the image. All in all, this behaviour breaks the non-text content success criterion from WCAG 2.2:

https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html

This issue is recorded here:

https://github.com/alphagov/tech-docs-gem/issues/355

## Notes for reviewers

Please check my Ruby code! My skills with Ruby are basic at best :)
