### PR TITLE
Include manifest.json from govuk-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- [Fix missing manifest.json from govuk-frontend](https://github.com/alphagov/tech-docs-gem/pull/376)
+
 ## 4.0.0
 
 ### Breaking

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   files_in_git = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   # Include assets from GOV.UK Frontend library in the distributed gem
-  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,mjs,woff,woff2,png,svg,ico}"]
+  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,mjs,woff,woff2,png,svg,ico}", "node_modules/govuk-frontend/dist/govuk/assets/manifest.json"]
 
   spec.files         = files_in_git + govuk_frontend_assets
 


### PR DESCRIPTION
This file specifies favicons and it needs to be bundled with the gem
