### PR TITLE
Warning text fix

### DIFF
--- a/lib/govuk_tech_docs/warning_text_extension.rb
+++ b/lib/govuk_tech_docs/warning_text_extension.rb
@@ -10,7 +10,7 @@ module GovukTechDocs
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
+            <span class="govuk-visually-hidden">Warning</span>
             #{text}
           </strong>
         </div>


### PR DESCRIPTION
## What’s changed

Fixed warning text component helper to bring it up to date with Gov UK frontend 5.7.1 https://design-system.service.gov.uk/components/warning-text/
<img width="292" alt="Screenshot 2024-11-13 at 11 41 10" src="https://github.com/user-attachments/assets/e92ff0d2-cec9-455c-8172-b11984742a36">

Before
<img width="296" alt="Screenshot 2024-11-13 at 11 40 48" src="https://github.com/user-attachments/assets/422cf2bf-4803-4fe8-ac8c-cea12582beb0">

After
<img width="222" alt="Screenshot 2024-11-13 at 11 35 25" src="https://github.com/user-attachments/assets/42213bd6-3bba-4a6f-a493-66621a0de8cb">

## Identifying a user need

Fixes a bug
