### PR TITLE
Disable focus outline on navigation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- [Disable focus outline on navigation link](https://github.com/alphagov/tech-docs-gem/pull/379)
 
 ## 4.1.0
 

--- a/lib/assets/stylesheets/modules/_toc.scss
+++ b/lib/assets/stylesheets/modules/_toc.scss
@@ -43,6 +43,7 @@
 
         a:focus {
           text-decoration: none;
+          outline: none;
 
           span {
             @include govuk-focused-text;


### PR DESCRIPTION
As we already apply a focus state to the link child element, there is no need for an additional focus outline on the link itself that User Agents apply as default

Before
<img width="321" alt="Screenshot 2024-11-14 at 09 59 15" src="https://github.com/user-attachments/assets/8e7b2725-a7e0-46db-8881-20337a682e1f">

After
<img width="312" alt="Screenshot 2024-11-14 at 09 59 29" src="https://github.com/user-attachments/assets/701c4594-74f4-419a-a53b-1cb22819dbdf">
