### PR TITLE
Release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## Unreleased
+## 4.1.1
+
+## Fixes
+
 - [Disable focus outline on navigation link](https://github.com/alphagov/tech-docs-gem/pull/379)
+- [Warning text extension fix for govuk-frontend v5.7.1](https://github.com/alphagov/tech-docs-gem/pull/378)
 
 ## 4.1.0
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "4.1.0".freeze
+  VERSION = "4.1.1".freeze
 end


### PR DESCRIPTION
## Fixes

- [Disable focus outline on navigation link](https://github.com/alphagov/tech-docs-gem/pull/379)
- [Warning text extension fix for govuk-frontend v5.7.1](https://github.com/alphagov/tech-docs-gem/pull/378)

