### PR TITLE
[NOT TO BE MERGED] Make search JS test fail to test runner

### DIFF
--- a/spec/javascripts/anchored-heading-spec.js
+++ b/spec/javascripts/anchored-heading-spec.js
@@ -13,7 +13,7 @@ describe('Anchored headings', function () {
   })
 
   it('adds an anchor to headings in the target element', function () {
-    expect($heading.find('a').length).toEqual(1)
+    expect($heading.find('a').length).toEqual(0)
   })
 
   it('sets the href of the anchor to the heading\'s id attribute', function () {


### PR DESCRIPTION
I want to check the tests are running correctly on github actions. In particular it's unclear whether the runner has a headless chrome to use.