### PR TITLE
Remove jasmine ruby gem and its requiring

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-require "jasmine"
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -57,7 +57,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "capybara", "~> 3.32"
-  spec.add_development_dependency "jasmine", "~> 3.5"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rubocop-govuk", "~> 4.10"

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64" # TODO: remove once middleman-sprockets declares this itself.
   spec.add_dependency "bigdecimal" # TODO: remove once activesupport declares this itself.
   spec.add_dependency "chronic", "~> 0.10.2"
+  spec.add_dependency "concurrent-ruby", "1.3.4" # 1.3.5 introduced a change that breaks activesupport, and so middleman
   spec.add_dependency "csv" # TODO: remove once tilt declares this itself.
   spec.add_dependency "haml", "~> 6.0"
   spec.add_dependency "middleman", "~> 4.0"


### PR DESCRIPTION
This was missed from the pull request that
replaced the jasmine ruby gem with the
jasmine-browser-runner:

https://github.com/alphagov/tech-docs-gem/pull/382

Note: this locks the `concurrent-ruby` gem to v1.3.4 due to changes in that version breaking the `activesupport` gem, and so middleman. This has been fixed in the `activesupport` code but not included on the v7.0 release track yet, from what I can tell, so we either wait for them to do that and middleman's gemspec should allow it to be picked up, or wait for middleman to change their gemspec semver range to include a higher release that does include it.