### PR TITLE
Allow non-GOV.UK favicon and opengraph assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- [Allow non-GOV.UK favicon and opengraph assets](https://github.com/alphagov/tech-docs-gem/pull/387)
+
+To use a non-crown assets, you need to 
+- add `favicon.ico`, `favicon.svg` and `opengraph-image.png` to your `source/images` folder.
+- set `show_govuk_logo: false`
+
 ## 4.1.2
 
 ## Fixes

--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -48,7 +48,11 @@ module GovukTechDocs
     attr_reader :config, :current_page
 
     def page_image
-      "#{host}/assets/govuk/assets/images/govuk-opengraph-image.png"
+      if config[:tech_docs][:show_govuk_logo]
+        "#{host}/assets/govuk/assets/images/govuk-opengraph-image.png"
+      else
+        "#{host}/images/opengraph-image.png"
+      end
     end
 
     def site_name

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -10,11 +10,16 @@
     <%= stylesheet_link_tag :manifest %>
 
     <link rel="canonical" href="<%= meta_tags.canonical_url %>">
-    <link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico">
-    <link rel="icon" sizes="any" href="/assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
-    <link rel="mask-icon" href="/assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" href="/assets/govuk/assets/images/govuk-icon-180.png">
-    <link rel="manifest" href="/assets/govuk/assets/manifest.json">
+    <% if config[:tech_docs][:show_govuk_logo] %>
+      <link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/govuk/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/govuk/assets/manifest.json">
+    <% else %>
+      <link rel="icon" sizes="48x48" href="/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/images/favicon.svg" type="image/svg+xml">
+    <% end %>
 
     <% meta_tags.tags.each do |name, content| %>
       <%= tag :meta, name: name, content: content %>

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe GovukTechDocs::MetaTags do
         host: "https://www.example.org",
         service_name: "Foo",
         full_service_name: "Test Site",
+        show_govuk_logo: true,
       )
 
       current_page = double("current_page",
@@ -51,6 +52,31 @@ RSpec.describe GovukTechDocs::MetaTags do
         "twitter:card" => "summary",
         "twitter:domain" => "www.example.org",
         "twitter:image" => "https://www.example.org/assets/govuk/assets/images/govuk-opengraph-image.png",
+        "twitter:title" => "The Title - Test Site",
+        "twitter:url" => "https://www.example.org/foo.html",
+      )
+    end
+
+    it "returns standard meta tag with non GOV.UK twitter image" do
+      config = generate_config(
+        host: "https://www.example.org",
+        service_name: "Foo",
+        full_service_name: "Test Site",
+        show_govuk_logo: false,
+      )
+
+      current_page = double("current_page",
+                            data: { description: "The description.", title: "The Title" },
+                            url: "/foo.html",
+                            metadata: { locals: {} })
+
+      tags = GovukTechDocs::MetaTags.new(config, current_page).tags
+
+      expect(tags).to eql(
+        "description" => "The description.",
+        "twitter:card" => "summary",
+        "twitter:domain" => "www.example.org",
+        "twitter:image" => "https://www.example.org/images/opengraph-image.png",
         "twitter:title" => "The Title - Test Site",
         "twitter:url" => "https://www.example.org/foo.html",
       )
@@ -128,6 +154,7 @@ RSpec.describe GovukTechDocs::MetaTags do
         host: "https://www.example.org",
         service_name: "Foo",
         full_service_name: "Test Site",
+        show_govuk_logo: true,
       )
 
       current_page = double("current_page",
@@ -140,6 +167,31 @@ RSpec.describe GovukTechDocs::MetaTags do
       expect(og_tags).to eql(
         "og:description" => "The description.",
         "og:image" => "https://www.example.org/assets/govuk/assets/images/govuk-opengraph-image.png",
+        "og:site_name" => "Test Site",
+        "og:title" => "The Title",
+        "og:type" => "object",
+        "og:url" => "https://www.example.org/foo.html",
+      )
+    end
+
+    it "returns a custom opengraph meta tag image" do
+      config = generate_config(
+        host: "https://www.example.org",
+        service_name: "Foo",
+        full_service_name: "Test Site",
+        show_govuk_logo: false,
+      )
+
+      current_page = double("current_page",
+                            data: { description: "The description.", title: "The Title" },
+                            url: "/foo.html",
+                            metadata: { locals: {} })
+
+      og_tags = GovukTechDocs::MetaTags.new(config, current_page).opengraph_tags
+
+      expect(og_tags).to eql(
+        "og:description" => "The description.",
+        "og:image" => "https://www.example.org/images/opengraph-image.png",
         "og:site_name" => "Test Site",
         "og:title" => "The Title",
         "og:type" => "object",


### PR DESCRIPTION
Fixes: https://github.com/alphagov/tech-docs-gem/issues/347

We already provide a way to non display the crown next to the service name by setting `show_govuk_logo: false` in config/tech-docs.yml. This is used by external users such as [MOJ](https://user-guide.modernisation-platform.service.justice.gov.uk).

This work extends the usage of that setting enabled custom favicon and opengraph image insted of the default Crown. It's limited to just the `favicon.ico`, `favicon.svg` and `opengraph-image.png`, but this should suffice.

Users need to create those assets and place them in their `source/images` folder.


**Before**

![Screenshot 2025-01-21 at 13 49 27](https://github.com/user-attachments/assets/8a33c88b-c44e-44b5-a9d2-d1e97cbbbf54)


**After**

![Screenshot 2025-01-21 at 13 48 43](https://github.com/user-attachments/assets/0ea740a9-12ed-4f17-9f2b-ce5b705d15a5)

