### PR TITLE
Release version 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 4.2.0
+
+## New features
 
 - [Allow non-GOV.UK favicon and opengraph assets](https://github.com/alphagov/tech-docs-gem/pull/387)
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "4.1.2".freeze
+  VERSION = "4.2.0".freeze
 end


### PR DESCRIPTION
## 4.2.0

## New features

- [Allow non-GOV.UK favicon and opengraph assets](https://github.com/alphagov/tech-docs-gem/pull/387)

To use a non-crown assets, you need to
- add `favicon.ico`, `favicon.svg` and `opengraph-image.png` to your `source/images` folder.
- set `show_govuk_logo: false`

<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->


## Identifying a user need

Fixes https://github.com/alphagov/tech-docs-gem/issues/347
