### PR TITLE
Bump govuk frontend to v5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [Bump govuk-frontend to v5.9.0 and pin middleman to v4.5.1](https://github.com/alphagov/tech-docs-gem/pull/390)
+
 ## 4.2.0
 
 ## New features

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "1.3.4" # 1.3.5 introduced a change that breaks activesupport, and so middleman
   spec.add_dependency "csv" # TODO: remove once tilt declares this itself.
   spec.add_dependency "haml", "~> 6.0"
-  spec.add_dependency "middleman", "~> 4.0"
+  spec.add_dependency "middleman", "4.5.1" # remove pin once https://github.com/middleman/middleman/issues/2818 is fixed
   spec.add_dependency "middleman-autoprefixer", "~> 2.10"
   spec.add_dependency "middleman-compass", "~> 4.0"
   spec.add_dependency "middleman-livereload"

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -7,6 +7,9 @@ $govuk-suppressed-warnings: (
 );
 $govuk-assets-path: "/assets/govuk/assets/" !default;
 
+// legacy palette is getting deprecated so new one needs to be used
+$govuk-new-organisation-colours: true;
+
 // Include only the bits of GOV.UK Frontend we need
 $govuk-new-link-styles: true;
 @import "govuk/base";

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "tech-docs-gem",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "~5.7.1"
+        "govuk-frontend": "~5.9.0"
       },
       "devDependencies": {
         "jasmine-browser-runner": "^2.5.0",
@@ -1663,9 +1663,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -5545,9 +5546,9 @@
       "dev": true
     },
     "govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg=="
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test-server": "jasmine-browser-runner serve --config=spec/javascripts/support/jasmine-browser.mjs"
   },
   "dependencies": {
-    "govuk-frontend": "~5.7.1"
+    "govuk-frontend": "~5.9.0"
   },
   "devDependencies": {
     "jasmine-browser-runner": "^2.5.0",


### PR DESCRIPTION
Bumps govuk-frontend to v5.9.0 and uses the new `$govuk-new-organisation-colours` map as `legacy-organisation-colours` map is getting deprecated.

[Deprecation](https://github.com/alphagov/govuk-frontend/releases#:~:text=Migrate%20to%20the%20new%20organisation%20colour%20palette)

[New palette released in v5.5.0](https://github.com/alphagov/govuk-frontend/releases#:~:text=in%20our%20documentation.-,New%20features,-We%27ve%20updated%20the)

Pins Middleman to v4.5.1 due to [a regression](https://github.com/middleman/middleman/issues/2818) in v4.6.0