### PR TITLE
Fix: Update Rack::File to Rack::Files in test specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - [Bump govuk-frontend to v5.9.0 and pin middleman to v4.5.1](https://github.com/alphagov/tech-docs-gem/pull/390)
 
+- [Fix: Update Rack::File to Rack::Files in test specs](https://github.com/alphagov/tech-docs-gem/pull/394)
+
 ## 4.2.0
 
 ## New features

--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -1,7 +1,7 @@
-require "rack/file"
+require "rack/files"
 require "capybara/rspec"
 
-Capybara.app = Rack::File.new("example/build")
+Capybara.app = Rack::Files.new("example/build")
 
 RSpec.describe "OpenAPI reference" do
   include Capybara::DSL

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -1,7 +1,7 @@
-require "rack/file"
+require "rack/files"
 require "capybara/rspec"
 
-Capybara.app = Rack::File.new("example/build")
+Capybara.app = Rack::Files.new("example/build")
 
 RSpec.describe "The tech docs template" do
   include Capybara::DSL

--- a/spec/features/page_expiration_spec.rb
+++ b/spec/features/page_expiration_spec.rb
@@ -1,7 +1,7 @@
-require "rack/file"
+require "rack/files"
 require "capybara/rspec"
 
-Capybara.app = Rack::File.new("example/build")
+Capybara.app = Rack::Files.new("example/build")
 
 RSpec.describe "Page expiration" do
   include Capybara::DSL


### PR DESCRIPTION
Updates deprecated Rack::File references to Rack::Files in integration and
feature specs to resolve LoadError failures. This change accommodates newer
Rack versions where the File module was renamed to Files.
