### PR TITLE
Release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.3.0
 
 - [Bump govuk-frontend to v5.9.0 and pin middleman to v4.5.1](https://github.com/alphagov/tech-docs-gem/pull/390)
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "4.2.0".freeze
+  VERSION = "4.3.0".freeze
 end


### PR DESCRIPTION
- [Bump govuk-frontend to v5.9.0 and pin middleman to v4.5.1](https://github.com/alphagov/tech-docs-gem/pull/390)

- [Fix: Update Rack::File to Rack::Files in test specs](https://github.com/alphagov/tech-docs-gem/pull/394)

- [Fix: Use the service link as the start of the path to the favicon images](https://github.com/alphagov/tech-docs-gem/pull/391) by @johnsgp
