### PR TITLE
Revert "Use the service link as the start of the path to the favicon images"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - [Fix: Update Rack::File to Rack::Files in test specs](https://github.com/alphagov/tech-docs-gem/pull/394)
 
-- [Fix: Use the service link as the start of the path to the favicon images](https://github.com/alphagov/tech-docs-gem/pull/391)
-
 ## 4.2.0
 
 ## New features

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -11,22 +11,11 @@
 
     <link rel="canonical" href="<%= meta_tags.canonical_url %>">
     <% if config[:tech_docs][:show_govuk_logo] %>
-      <%
-        if development?
-          path_prefix = '/'
-        else
-          path_prefix = config[:tech_docs][:service_link] || '/'
-          # ensure service_link ends with a trailing '/'
-          if path_prefix[-1, 1] != '/'
-            path_prefix += '/'
-          end
-        end
-      %>
-      <link rel="icon" sizes="48x48" href="<%= path_prefix %>assets/govuk/assets/images/favicon.ico">
-      <link rel="icon" sizes="any" href="<%= path_prefix %>assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
-      <link rel="mask-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-      <link rel="apple-touch-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-180.png">
-      <link rel="manifest" href="<%= path_prefix %>assets/govuk/assets/manifest.json">
+      <link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/govuk/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/govuk/assets/manifest.json">
     <% else %>
       <link rel="icon" sizes="48x48" href="/images/favicon.ico">
       <link rel="icon" sizes="any" href="/images/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
Reverts alphagov/tech-docs-gem#391

This doesn't work when docs are published on a subdomain to the service

<img width="719" alt="Screenshot 2025-04-30 at 14 50 57" src="https://github.com/user-attachments/assets/aeff39b1-3ed4-493b-9687-1bd9c56cb81e" />


<img width="515" alt="Screenshot 2025-04-30 at 14 46 28" src="https://github.com/user-attachments/assets/14733ff4-2ae6-46ac-9afc-59c54c686c68" />
