### PR TITLE
Use the service_link at the start of the path to the favicon images i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- [Fix: Use the service link as the start of the path to the favicon images if required](https://github.com/alphagov/tech-docs-gem/pull/399)
+
+To use the service_link at the start of the path to the favicon images, you need to
+- set `use_service_link_for_favicon: true`
+
 ## 4.3.1
 
 - Revert [Fix: Use the service link as the start of the path to the favicon images](https://github.com/alphagov/tech-docs-gem/pull/391)

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -11,11 +11,24 @@
 
     <link rel="canonical" href="<%= meta_tags.canonical_url %>">
     <% if config[:tech_docs][:show_govuk_logo] %>
-      <link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico">
-      <link rel="icon" sizes="any" href="/assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
-      <link rel="mask-icon" href="/assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-      <link rel="apple-touch-icon" href="/assets/govuk/assets/images/govuk-icon-180.png">
-      <link rel="manifest" href="/assets/govuk/assets/manifest.json">
+      <%
+        path_prefix =
+          if !development? && config[:tech_docs][:use_service_link_for_favicon]
+            service_link = config[:tech_docs][:service_link] || '/'
+            # ensure service_link ends with a trailing '/'
+            if service_link[-1, 1] != '/'
+              service_link += '/'
+            end
+            service_link
+          else
+            '/'
+          end
+      %>
+      <link rel="icon" sizes="48x48" href="<%= path_prefix %>assets/govuk/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="<%= path_prefix %>assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="<%= path_prefix %>assets/govuk/assets/manifest.json">
     <% else %>
       <link rel="icon" sizes="48x48" href="/images/favicon.ico">
       <link rel="icon" sizes="any" href="/images/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
## What’s changed

The location of the favicons in the page `<head>` has been changed to include the `service_link` from the [tech-docs.yml](https://github.com/alphagov/tech-docs-gem/blob/main/example/config/tech-docs.yml#L7) configuration file, only if `use_service_link_for_favicon` is set to true (default: false).

## Identifying a user need

The favicon links [added to the core template in v4.0.0](https://github.com/alphagov/tech-docs-gem/commit/01829189c5a9888f532bb06f608035c011e5d109) does not work for sites that have a service link. As an example, see the [Self Assessment End-to-End Service Guide](https://developer.service.hmrc.gov.uk/guides/self-assessment-end-to-end-service-guide/) which has its [source in GitHub](https://github.com/hmrc/self-assessment-end-to-end-service-guide). There is no favicon on the browser tab because the links look like
```<link rel="icon" sizes="48x48" href="/assets/govuk/assets/images/favicon.ico">```
which resolves to https://developer.service.hmrc.gov.uk/assets/govuk/assets/images/favicon.ico which does not exist. The icon is located at https://developer.service.hmrc.gov.uk/guides/self-assessment-end-to-end-service-guide/assets/govuk/assets/images/favicon.ico. The [service_link configuration](https://github.com/hmrc/self-assessment-end-to-end-service-guide/blob/main/config/tech-docs.yml#L5) matches what is missing from the link.

This was raised as an issue by a service guide author. There are [2 dozen or more service guides and roadmaps](https://developer.service.hmrc.gov.uk/api-documentation/docs/api?docTypeFilters=ROADMAPANDSERVICEGUIDE) that either already are or will be affected when updated.

This cannot be applied to all services, so needs an additional switch, `use_service_link_for_favicon` to be set to true.
