### PR TITLE
Remove ARIA labels from containers

### DIFF
--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -66,7 +66,7 @@
       <div class="app-pane__body"<%= " data-module=\"#{yield_content(:toc_module)}\"" if content_for? :toc_module %>>
         <% if content_for? :sidebar %>
           <div class="app-pane__toc">
-            <div class="toc" data-module="table-of-contents" tabindex="-1" aria-label="Table of contents">
+            <div class="toc" data-module="table-of-contents" tabindex="-1">
               <%= partial "layouts/search" %>
               <button type="button" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></button>
               <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading"<%= " data-module=\"collapsible-navigation\"" if config[:tech_docs][:collapsible_nav] %>>
@@ -76,7 +76,7 @@
           </div>
         <% end %>
 
-        <div class="app-pane__content toc-open-disabled" aria-label="Content">
+        <div class="app-pane__content toc-open-disabled">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
             <%= yield %>
             <%= partial "layouts/page_review" %>


### PR DESCRIPTION
## What’s changed

This PR removes unnecessary ARIA labels from the menu container and the main content window.

These aria-labels are used incorrectly as they are applied to `<div>` elements with no role. This is not permitted under the [ARIA specification](https://www.w3.org/TR/wai-aria/#aria-label) as a `<div>` has a role of `generic`. They are also unnecessary as:

- the `<nav>` element already has an appropriate label
- the main content is within a `main` landmark and so an aria-label is unnecessary for its container. We could move the aria-label to `<main>` instead but while permitted, my understanding is that it would be unnecessary.

I've tested it locally using VoiceOver and:

- the side navigation is correctly noted as "Table of contents"
- the `main` landmark is correctly identified as `main`

I believe this fixes #404 .

## Identifying a user need

This came out of testing by Shabana Ali in the WCAG Primer working group, who identified the incorrect ARIA usage. We believe fails Web Content Accessibility Guidelines ([4.1.2 Name, Role, Value -  level A](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value))