### PR TITLE
Add aria-current to active header menu link

### DIFF
--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -40,7 +40,7 @@
         <ul id="navigation" class="govuk-header__navigation-list">
           <% config[:tech_docs][:header_links].each do |title, path| %>
             <li class="govuk-header__navigation-item<% if active_page(path) %> govuk-header__navigation-item--active<% end %>">
-              <a class="govuk-header__link" href="<%= get_path_to_resource config, path, current_page %>"><%= title %></a>
+              <a class="govuk-header__link" href="<%= get_path_to_resource config, path, current_page %>"<% if active_page(path) %> aria-current="page"<% end %>><%= title %></a>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
## What’s changed

This PR adds `aria-current="page"` to the currently highlighted menu item in the page header. I believe this fixes #403, an accessibility issue where the currently active link was only conveyed using a change of colour.

I've tested this on the example site using VoiceOver on Safari and Chrome. The currently active page reads correctly as "current page", and any non-current pages do not include this label.

## Identifying a user need

This came out of accessibility testing in the WCAG Primer working group by Shabana Ali. As the information is only conveyed visually and not programmatically, we believe it currently fails WCAG ([1.3.1 Info and Relationships - level A](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships)).