### PR TITLE
Add toggle for anchored headings

### DIFF
--- a/example/config/tech-docs.yml
+++ b/example/config/tech-docs.yml
@@ -40,6 +40,9 @@ google_site_verification: dstbao8TVS^DRVDS&rv76
 
 enable_search: true
 
+# Enable hoverable anchor links next to every heading
+enable_anchored_headings: true
+
 show_contribution_banner: true
 
 github_repo: alphagov/example-repo

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -77,7 +77,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled" aria-label="Content">
-          <main id="content" class="technical-documentation" data-module="anchored-headings">
+          <main id="content" class="technical-documentation"<%= " data-module=\"anchored-headings\"" if config[:tech_docs][:enable_anchored_headings] %>>
             <%= yield %>
             <%= partial "layouts/page_review" %>
           </main>


### PR DESCRIPTION
## What’s changed

This PR adds a toggle option for anchored headings, where a hoverable link appears next to each heading in the main page body. It uses the same syntax as the `collapsible_nav` functionality.

As these links are not currently keyboard or screen reader accessible, the option to remove them is needed for a repository to meet Web Content Accessibility Guidelines. The [WCAG Primer](https://github.com/alphagov/wcag-primer) working group has also expressed a desire to turn these links off to reduce unnecessary page "noise".

While this does not completely fix issue #402 by making the links accessible (which would be a bigger fix), it does provide a workaround for it, as well as adding extra flexibility to the template.

I've tested it locally and it works as expected (you need to restart Middleman when changing the toggle). The default value for the new toggle is set to `true`, to reflect the behaviour that all Tech Docs repositories currently have.

## Identifying a user need

This came out of accessibility testing by Shabana Ali as part of the WCAG Primer working group. As the anchor links are not keyboard or screen reader accessible, we believe they fail WCAG ([2.1.2 Keyboard - level A](https://www.w3.org/WAI/WCAG22/Understanding/keyboard), and [4.1.2 Name, Role Value - level A](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value)).