### PR TITLE
Update path to GOV.UK Frontend assets when using GOV.UK logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - [Update logo SVG in header](https://github.com/alphagov/tech-docs-gem/pull/418)
+- [Update path to GOV.UK Frontend assets when using GOV.UK logo](https://github.com/alphagov/tech-docs-gem/pull/419)
 
 ## 5.0.0
 

--- a/lib/govuk_tech_docs/meta_tags.rb
+++ b/lib/govuk_tech_docs/meta_tags.rb
@@ -49,7 +49,7 @@ module GovukTechDocs
 
     def page_image
       if config[:tech_docs][:show_govuk_logo]
-        "#{host}/assets/govuk/assets/images/govuk-opengraph-image.png"
+        "#{host}/assets/govuk/assets/rebrand/images/govuk-opengraph-image.png"
       else
         "#{host}/images/opengraph-image.png"
       end

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -24,11 +24,11 @@
             '/'
           end
       %>
-      <link rel="icon" sizes="48x48" href="<%= path_prefix %>assets/govuk/assets/images/favicon.ico">
-      <link rel="icon" sizes="any" href="<%= path_prefix %>assets/govuk/assets/images/favicon.svg" type="image/svg+xml">
-      <link rel="mask-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-      <link rel="apple-touch-icon" href="<%= path_prefix %>assets/govuk/assets/images/govuk-icon-180.png">
-      <link rel="manifest" href="<%= path_prefix %>assets/govuk/assets/manifest.json">
+      <link rel="icon" sizes="48x48" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/favicon.ico">
+      <link rel="icon" sizes="any" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/govuk-icon-180.png">
+      <link rel="manifest" href="<%= path_prefix %>assets/govuk/assets/rebrand/manifest.json">
     <% else %>
       <link rel="icon" sizes="48x48" href="/images/favicon.ico">
       <link rel="icon" sizes="any" href="/images/favicon.svg" type="image/svg+xml">

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -151,5 +151,16 @@ RSpec.describe "The tech docs template" do
     expect(page).to have_css ".govuk-logo-dot"
     # Check for crown svg in footer
     expect(page).to have_css ".govuk-footer__crown"
+    # Check for favicons and other meta tags
+    # <link rel="icon" sizes="48x48" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/favicon.ico">
+    expect(page).to have_css 'link[rel="icon"][sizes="48x48"][href$="assets/govuk/assets/rebrand/images/favicon.ico"]', visible: false
+    # <link rel="icon" sizes="any" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/favicon.svg" type="image/svg+xml">
+    expect(page).to have_css 'link[rel="icon"][sizes="any"][type="image/svg+xml"][href$="assets/govuk/assets/rebrand/images/favicon.svg"]', visible: false
+    # <link rel="mask-icon" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/govuk-icon-mask.svg" color="#0b0c0c">
+    expect(page).to have_css 'link[rel="mask-icon"][href$="assets/govuk/assets/rebrand/images/govuk-icon-mask.svg"][color="#0b0c0c"]', visible: false
+    # <link rel="apple-touch-icon" href="<%= path_prefix %>assets/govuk/assets/rebrand/images/govuk-icon-180.png">
+    expect(page).to have_css 'link[rel="apple-touch-icon"][href$="assets/govuk/assets/rebrand/images/govuk-icon-180.png"]', visible: false
+    # <link rel="manifest" href="<%= path_prefix %>assets/govuk/assets/rebrand/manifest.json">
+    expect(page).to have_css 'link[rel="manifest"][href$="assets/govuk/assets/rebrand/manifest.json"]', visible: false
   end
 end

--- a/spec/govuk_tech_docs/meta_tags_spec.rb
+++ b/spec/govuk_tech_docs/meta_tags_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GovukTechDocs::MetaTags do
         "description" => "The description.",
         "twitter:card" => "summary",
         "twitter:domain" => "www.example.org",
-        "twitter:image" => "https://www.example.org/assets/govuk/assets/images/govuk-opengraph-image.png",
+        "twitter:image" => "https://www.example.org/assets/govuk/assets/rebrand/images/govuk-opengraph-image.png",
         "twitter:title" => "The Title - Test Site",
         "twitter:url" => "https://www.example.org/foo.html",
       )
@@ -166,7 +166,7 @@ RSpec.describe GovukTechDocs::MetaTags do
 
       expect(og_tags).to eql(
         "og:description" => "The description.",
-        "og:image" => "https://www.example.org/assets/govuk/assets/images/govuk-opengraph-image.png",
+        "og:image" => "https://www.example.org/assets/govuk/assets/rebrand/images/govuk-opengraph-image.png",
         "og:site_name" => "Test Site",
         "og:title" => "The Title",
         "og:type" => "object",


### PR DESCRIPTION
These were pointing to the locations before the brand refresh, so the wrong favicon were showing. Includes the favicons in the header, as well as the Open Graph image.

Paths to the assets when not using the GOV.UK logo were left untouched, as they are built from separate options.

In action:
<img width="1624" alt="Screenshot of the Tech Docs gem with the right paths for the favicons" src="https://github.com/user-attachments/assets/cb78895e-6fb3-402e-b367-d0c7c314e711" />
