### PR TITLE
Fix copy of `manifest.json` into build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixes
+
+- [Fix copy of manifest.json into build](https://github.com/alphagov/tech-docs-gem/pull/423)
+
 ## 5.0.1
 
 ### Fixes

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   files_in_git = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   # Include assets from GOV.UK Frontend library in the distributed gem
-  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,mjs,woff,woff2,png,svg,ico}", "node_modules/govuk-frontend/dist/govuk/assets/manifest.json"]
+  govuk_frontend_assets = Dir["node_modules/govuk-frontend/**/*.{scss,js,mjs,woff,woff2,png,svg,ico}", "node_modules/govuk-frontend/dist/govuk/assets/**/*.json"]
 
   spec.files         = files_in_git + govuk_frontend_assets
 


### PR DESCRIPTION
Uses a glob to target any JSON file within the `assets` folder of GOV.UK Frontend so that future changes of manifest location get copied properly.

This needs to be a separate glob from the initial list to not copy other JSON files in the package, like `package.json` and similar. Only the assets need copying.
