### PR TITLE
Ruby versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['3.2', '3.3']
+        ruby: ['3.2', '3.3', '3.4']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What’s changed

We've been testing Ruby version 3.1 but that's out of security updates.
We also don't test 3.4 which is the latest

## Identifying a user need

part of debugging a recent test failure I can only reproduce in GitHub actions,
I don't think this solves it, but we should keep our ruby versions and tests up to date with language support.