### PR TITLE
Lock middleman-syntax to v3.6+

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-livereload"
   spec.add_dependency "middleman-search-gds"
   spec.add_dependency "middleman-sprockets", "~> 4.0.0"
-  spec.add_dependency "middleman-syntax", "~> 3.4"
+  spec.add_dependency "middleman-syntax", "~> 3.6"
   spec.add_dependency "mutex_m" # TODO: remove once activesupport declares this itself.
   spec.add_dependency "nokogiri"
   spec.add_dependency "openapi3_parser", "~> 0.9.0"


### PR DESCRIPTION
v3.6 actually had an issue that has been solved by the release of v3.6.1 it was causing our tests to fail here, but has been fixed upstream:

https://github.com/middleman/middleman-syntax/releases/tag/v3.6.1 https://github.com/middleman/middleman-syntax/pull/94

Theoretically doing nothing is fine, but thought, why not push this up to 3.6+ whilst we're at it. Especially if thats what we're testing against now with new Lexer options