### PR TITLE
Change `npm install` to `npm ci`

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -4,8 +4,8 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "govuk_tech_docs/version"
 
-`npm install`
-abort "npm install failed" unless $CHILD_STATUS.success?
+`npm ci`
+abort "npm ci failed" unless $CHILD_STATUS.success?
 
 unless File.exist?("node_modules/govuk-frontend/dist/govuk/all.scss")
   abort "govuk-frontend npm package not installed"


### PR DESCRIPTION
## What’s changed

Change uses of `npm install` in the gemspec file to instead use `npm ci`, to ensure no npm packages used by the gem get updated when the gem is installed.

## Identifying a user need

Users of the gem should be able to know, and query, which npm packages the gem will install on their machine/environment at any given time. This is easy to do with `npm ci`, because it just installs what's in `package-lock.json` from scratch whereas `npm install` will install whatever npm packages satisfy the versions specified in `package.json`.

## Notes for reviewers

Please check the logic behind these changes, described in the commit message, before approving. These changes make the assumption that the only difference this will make to users of the gem is the lack of any changes to the npm packages in their node_modules folder.
