### PR TITLE
Fix `select_top_level_html_files` ignoring custom `http_prefix`

### DIFF
--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -30,14 +30,16 @@ module GovukTechDocs
           .to_a
       end
 
-      def select_top_level_html_files(resources)
+      def select_top_level_html_files(resources, config)
+        home_url = config[:http_prefix].end_with?("/") ? config[:http_prefix] : "#{config[:http_prefix]}/"
+
         resources
-          .select { |r| r.path.end_with?(".html") && (r.parent.nil? || r.parent.url == "/") }
+          .select { |r| r.path.end_with?(".html") && (r.parent.nil? || r.parent.url == home_url) }
       end
 
       def multi_page_table_of_contents(resources, current_page, config, current_page_html = nil)
         resources = sort_resources_stably(
-          select_top_level_html_files(resources),
+          select_top_level_html_files(resources, config),
         )
 
         render_page_tree(resources, current_page, config, current_page_html)

--- a/spec/table_of_contents/helpers_spec.rb
+++ b/spec/table_of_contents/helpers_spec.rb
@@ -342,6 +342,24 @@ describe GovukTechDocs::TableOfContents::Helpers do
       expect(subject.multi_page_table_of_contents(resources, current_page, config, current_page_html).strip).to eq(expected_multi_page_table_of_contents.strip)
     end
 
+    it "selects top-level pages whose parent URL matches the http prefix" do
+      prefix_root = FakeResource.new("/prefix/", "")
+      resources = []
+      resources[0] = FakeResource.new("/prefix/index.html", '<h1 id="heading-one">Heading one</h1>', 10, "Index", prefix_root)
+      resources[1] = FakeResource.new("/prefix/a.html", '<h1 id="heading-one">Heading one</h1>', 20, "Page A", prefix_root)
+
+      config = {
+        http_prefix: "/prefix",
+        tech_docs: {
+          max_toc_heading_level: 3,
+        },
+      }
+
+      result = subject.select_top_level_html_files(resources, config)
+
+      expect(result).to eq(resources)
+    end
+
     it "builds a table of contents from a single page resources" do
       resources = []
       resources.push FakeResource.new("/index.html", '<h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2><h1 id="heading-one">Heading one</h1><h2 id="heading-two">Heading two</h2>')


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->

When we configure a custom `http_prefix` (e.g. /docs) to serve our tech docs site under a subpath, Middleman sets the parent URL of top-level pages to `/docs/` rather than `/`.

`select_top_level_html_files` had the parent URL check hardcoded to "/", so it filtered out all our top-level pages — meaning the multi-page table of contents came back empty.

`render_page_tree` (in the same file) already handled this correctly by computing `home_url` from `config[:http_prefix]`. `select_top_level_html_files` just wasn't updated to match.

[Here is where we've had to monkey patch the library](https://github.com/DFE-Digital/publish-teacher-training/blob/main/docs/config.rb#L6-L14)

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->
