### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This repository contains automated JavaScript tests that use the [Jasmine test f
 
 You can run these tests and see the results in your browser.
 
-1. Run `bundle exec rake jasmine`.
+1. Run `bundle exec rake jasmine:server`.
 2. Go to `http://localhost:8888` in your browser.
 
 To run the tests and see the results in your terminal, run:


### PR DESCRIPTION
There is no `jasmine` rake task. Results of running `rake --tasks` is:

```bash
rake build            # Build govuk_tech_docs-5.2.0.gem into the pkg directory
rake build:checksum   # Generate SHA512 checksum if govuk_tech_docs-5.2.0.gem into the checksums directory
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake install          # Build and install govuk_tech_docs-5.2.0.gem into system gems
rake install:local    # Build and install govuk_tech_docs-5.2.0.gem into system gems without network access
rake jasmine:ci       # Test JavaScript with headless browser
rake jasmine:server   # Test JavaScript in browser
rake lint             # Lint Ruby and JavaScript
rake release[remote]  # Create tag v5.2.0 and build and push govuk_tech_docs-5.2.0.gem to rubygems.org
rake spec             # Run RSpec code examples
```

<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->
Fixing a typo in the README referencing a rake task that doesn't exist.

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->
Developers running the tests need the instructions to describe actions that exist (not being facetious, promise).