### PR TITLE
Unpin middleman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.2
+
+- [Unpin middleman](https://github.com/alphagov/tech-docs-gem/pull/457)
+
 ## 5.2.1
 
 - [Add option to not render child resources when creating a table of contents](https://github.com/alphagov/tech-docs-gem/pull/439/changes)

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "1.3.4" # 1.3.5 introduced a change that breaks activesupport, and so middleman
   spec.add_dependency "csv" # TODO: remove once tilt declares this itself.
   spec.add_dependency "haml", "~> 6.0"
-  spec.add_dependency "middleman", "4.5.1" # remove pin once https://github.com/middleman/middleman/issues/2818 is fixed
+  spec.add_dependency "middleman", "~> 4.6.1"
   spec.add_dependency "middleman-autoprefixer", "~> 2.10"
   spec.add_dependency "middleman-compass", "~> 4.0"
   spec.add_dependency "middleman-livereload"

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "5.2.1".freeze
+  VERSION = "5.2.2".freeze
 end


### PR DESCRIPTION
This is causing issues when trying to upgrade activesupport (from versions with security vulnerabilities) as `middleman` v4.5.1 requires `activesupport` < 7.1.

The issue was resolved in v4.6.1
https://github.com/middleman/middleman/blob/main/CHANGELOG.md#461

It has been tested by serving https://github.com/alphagov/govuk-content-api-docs locally using this branch.