### PR TITLE
[PP-7656] Update `openapi3_parser` to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Update version of `openapi3_parser` allowing support for Ruby 4.0.
+
 ## 6.0.0
 
 - [Bump Design System to V6](https://github.com/alphagov/tech-docs-gem/pull/442), which brings in:

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-syntax", "~> 3.6"
   spec.add_dependency "mutex_m" # TODO: remove once activesupport declares this itself.
   spec.add_dependency "nokogiri"
-  spec.add_dependency "openapi3_parser", "~> 0.9.0"
+  spec.add_dependency "openapi3_parser", "~> 0.10.1"
   spec.add_dependency "redcarpet", "~> 3.6"
   spec.add_dependency "sassc-embedded", "~> 1.78.0"
   spec.add_dependency "terser", "~> 1.2.3"


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

Updates the `openapi3_parser` dependency to the latest version.


## Identifying a user need

`openapi3_parser` 0.9.0 has a dependency on `commonmarker` 0.x, which does not support Ruby 4.

Updating to 0.10.x, which allows us to use `commonmarker > 1`, therefore unlocking the Ruby 4 upgrade in apps that use this gem.
