### PR TITLE
Skip npm ci call in dependabot bundler job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,10 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
+    env:
+      DEPENDABOT_JOB: "true"
     commit-message:
       prefix: chore
-    # TODO - add labels
-    # labels:
-    #   - "dependencies"
-    #   - "ruby"
-    #   - "automated-pr"
     open-pull-requests-limit: 5
 
   # 2. Update GitHub Actions (keeps your CI workflows secure)

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -4,8 +4,12 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "govuk_tech_docs/version"
 
-`npm ci`
-abort "npm ci failed" unless $CHILD_STATUS.success?
+if ENV["DEPENDABOT_JOB"] == "true" # dependabot will only evaluate the bundler, and will not allow npm
+  warn "Skipping npm ci due to DEPENDABOT_JOB=true"
+else
+  system("npm ci")
+  abort "npm ci failed" unless $CHILD_STATUS.success?
+end
 
 unless File.exist?("node_modules/govuk-frontend/dist/govuk/_base.scss")
   abort "govuk-frontend npm package not installed"
@@ -45,9 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "middleman-compass"
   spec.add_dependency "middleman-livereload"
   spec.add_dependency "middleman-search-gds"
-=begin
-middleman-sprockets is very old and out of date.  V4.1.0 has a breaking change.  Will look to replace with gem "dartsass-sprockets" or uses sass in the package.json
-=end
+  # middleman-sprockets is very old and out of date.  V4.1.0 has a breaking change.  Will look to replace with gem "dartsass-sprockets" or uses sass in the package.json
   spec.add_dependency "middleman-sprockets", "4.0.0"
   spec.add_dependency "middleman-syntax"
   spec.add_dependency "mutex_m" # TODO: remove once activesupport declares this itself.


### PR DESCRIPTION
## Proposed changes

### What changed

This is a small change to allow the dependabot job to run against the `bundler`

```
if ENV["DEPENDABOT_JOB"] == "true" # dependabot will only evaluate the bundler, and will not allow npm
  warn "Skipping npm ci due to DEPENDABOT_JOB=true"
else
  system("npm ci")
  abort "npm ci failed" unless $CHILD_STATUS.success?
end
```

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- [Fixes #](https://github.com/alphagov/tech-docs-gem/network/updates/3075469/jobs)


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed