### PR TITLE
Fix TOC sidebar not scrolling to active item on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.3
+
+- [Fix TOC sidebar not scrolling to active item on page load](https://github.com/alphagov/tech-docs-gem/pull/480)
+
 ## 6.2.2
 
 - Update [govuk_tech_docs.gemspec](govuk_tech_docs.gemspec) to only run `npm` if `npm` is installed.  Allows gem versions scans to complete properly.

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -2,13 +2,11 @@
   'use strict'
 
   Modules.InPageNavigation = function InPageNavigation () {
-    var $tocPane
-    var $contentPane
-    var $tocItems
-    var $targets
+    let $contentPane
+    let $tocItems
+    let $targets
 
     this.start = function start ($element) {
-      $tocPane = $element.find('.app-pane__toc')
       $contentPane = $element.find('.app-pane__content')
       $tocItems = $('.js-toc-list').find('a')
       $targets = $contentPane.find('[id]')
@@ -29,7 +27,7 @@
         } else {
           // Store the initial position so that we can restore it even if we
           // never scroll.
-          handleInitialLoadEvent()
+          window.requestAnimationFrame(handleInitialLoadEvent)
         }
       }
     }
@@ -41,7 +39,7 @@
     }
 
     function handleInitialLoadEvent () {
-      var fragment = fragmentForTargetElement()
+      let fragment = fragmentForTargetElement()
 
       if (!fragment) {
         fragment = fragmentForFirstElementInView()
@@ -51,7 +49,7 @@
     }
 
     function handleScrollEvent () {
-      var fragment = fragmentForFirstElementInView()
+      const fragment = fragmentForFirstElementInView()
 
       storeCurrentPositionInHistoryApi(fragment)
       highlightActiveItemInToc(fragment)
@@ -70,8 +68,8 @@
     function highlightActiveItemInToc (fragment) {
       // Navigation items for single page navigation don't necessarily include the path name, but
       // navigation items for multipage navigation items do include it. This checks for either case.
-      var $activeTocItem = $tocItems.filter(function (_) {
-        var url = new URL($(this).attr('href'), window.location.href)
+      let $activeTocItem = $tocItems.filter(function (_) {
+        const url = new URL($(this).attr('href'), window.location.href)
         return url.href === window.location.href
       })
 
@@ -79,7 +77,7 @@
       // Check to see if any nav items contain just the path name.
       if (!$activeTocItem.get(0)) {
         $activeTocItem = $tocItems.filter(function (_) {
-          var url = new URL($(this).attr('href'), window.location.href)
+          const url = new URL($(this).attr('href'), window.location.href)
           return url.hash === '' && url.pathname === window.location.pathname
         })
       }
@@ -91,23 +89,10 @@
     }
 
     function scrollTocToActiveItem ($activeTocItem) {
-      var paneHeight = $tocPane.height()
-      var linkTop = $activeTocItem.position().top
-      var linkBottom = linkTop + $activeTocItem.outerHeight()
-
-      var offset = null
-
-      if (linkTop < 0) {
-        offset = linkTop
-      } else if (linkBottom >= paneHeight) {
-        offset = -(paneHeight - linkBottom)
-      } else {
-        return
+      const el = $activeTocItem.get(0)
+      if (el && typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ block: 'nearest', inline: 'nearest' })
       }
-
-      var newScrollTop = $tocPane.scrollTop() + offset
-
-      $tocPane.scrollTop(newScrollTop)
     }
 
     function fragmentForTargetElement () {
@@ -115,14 +100,14 @@
     }
 
     function fragmentForFirstElementInView () {
-      var result = null
+      let result = null
 
       $($targets.get().reverse()).each(function checkIfInView (index) {
         if (result) {
           return
         }
 
-        var $this = $(this)
+        const $this = $(this)
 
         if (Math.floor($this.position().top) <= 0) {
           result = $this

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -84,15 +84,12 @@
       if ($activeTocItem.get(0)) {
         $tocItems.removeClass('toc-link--in-view')
         $activeTocItem.addClass('toc-link--in-view')
-        scrollTocToActiveItem($activeTocItem)
+        scrollTocToActiveItem($activeTocItem.get(0))
       }
     }
 
-    function scrollTocToActiveItem ($activeTocItem) {
-      const el = $activeTocItem.get(0)
-      if (el && typeof el.scrollIntoView === 'function') {
-        el.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-      }
+    function scrollTocToActiveItem (activeTocElement) {
+      activeTocElement.scrollIntoView({ block: 'nearest', inline: 'nearest' })
     }
 
     function fragmentForTargetElement () {

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.2.2".freeze
+  VERSION = "6.2.3".freeze
 end

--- a/spec/javascripts/table-of-contents-spec.js
+++ b/spec/javascripts/table-of-contents-spec.js
@@ -472,3 +472,56 @@ describe('Table of contents', function () {
     })
   })
 })
+
+describe('In page navigation', function () {
+  'use strict'
+
+  var $element
+  var $tocList
+  var module
+  var _requestAnimationFrame
+  var _Modernizr
+
+  beforeEach(function () {
+    _requestAnimationFrame = window.requestAnimationFrame
+    _Modernizr = window.Modernizr
+    window.Modernizr = { history: true }
+
+    $element = $('<div><div class="app-pane__content"></div></div>')
+    $tocList = $(
+      '<nav class="js-toc-list">' +
+        '<a href="' + window.location.href + '">Current page</a>' +
+      '</nav>'
+    )
+    $('body').append($element).append($tocList)
+  })
+
+  afterEach(function () {
+    window.requestAnimationFrame = _requestAnimationFrame
+    window.Modernizr = _Modernizr
+    $element.remove()
+    $tocList.remove()
+  })
+
+  it('defers initial TOC highlighting using requestAnimationFrame', function () {
+    var rafSpy = jasmine.createSpy('requestAnimationFrame')
+    window.requestAnimationFrame = rafSpy
+
+    module = new GOVUK.Modules.InPageNavigation()
+    module.start($element)
+
+    expect(rafSpy).toHaveBeenCalled()
+  })
+
+  it('calls scrollIntoView on the active TOC link', function () {
+    var scrollIntoViewSpy = jasmine.createSpy('scrollIntoView')
+    $tocList.find('a').get(0).scrollIntoView = scrollIntoViewSpy
+
+    window.requestAnimationFrame = function (callback) { callback() }
+
+    module = new GOVUK.Modules.InPageNavigation()
+    module.start($element)
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' })
+  })
+})


### PR DESCRIPTION
## Proposed changes

### What changed

`scrollTocToActiveItem()` in `_modules/in-page-navigation.js` used jQuery's `position().top` to compute whether the active TOC item needed scrolling into view. 

When called on initial page load (via `handleInitialLoadEvent`), the browser has not yet finished layout, so `position().top` returns 0 and the function silently exits without scrolling.

Two fixes:
- Wrap the initial-load call in `requestAnimationFrame` so layout is complete  before positions are read.
- Replace the manual offset calculation with the browser-native `scrollIntoView({ block: 'nearest', inline: 'nearest' })`, which is simpler and handles all edge cases.

Also:
-  converts var to let/const throughout the file (as flagged by the linter)

## Related issue or tracking reference

- Fixes  #479 

## Screenshots or examples (if relevant)

### Before

https://github.com/user-attachments/assets/15aca9b0-7e4e-4cee-9e5f-62b7a335e56e

### After

https://github.com/user-attachments/assets/c0e0f76e-4e94-4711-b079-04d85a376d48

## Checklist

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [ ] you have updated documentation if needed
