### PR TITLE
Hotfix: Make npm call conditional on it existing in the environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ version: 2
 updates:
   # 1. Update Ruby dependencies (Gemfile/gemspec) in the root
   - package-ecosystem: "bundler"
-    directory: "/" 
+    directory: "/"
+    target-branch: "hotfix/only-call-npm-when-building"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,22 @@ updates:
   # 1. Update Ruby dependencies (Gemfile/gemspec) in the root
   - package-ecosystem: "bundler"
     directory: "/"
-    target-branch: "hotfix/only-call-npm-when-building"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
     commit-message:
       prefix: chore
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    groups:
+      prod-safe-updates:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
 
   # 2. Update GitHub Actions (keeps your CI workflows secure)
   - package-ecosystem: "github-actions"
@@ -30,26 +38,29 @@ updates:
       github-actions-updates:
         patterns:
           - "*"
+
   - package-ecosystem: "npm"
     directory: "/" 
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-    open-pull-requests-limit: 5
-    
+    open-pull-requests-limit: 3
     groups:
       # Group all "development" dependencies (linters, test runners, etc.)
       dev-dependencies:
         dependency-type: "development"
+        patterns:
+          - "*"
         update-types:
           - "patch"
           - "minor"
-      
       # Group all "production" dependencies (react, express, etc.) 
       # but ONLY for minor/patch versions to avoid breaking changes
       prod-safe-updates:
         dependency-type: "production"
+        patterns:
+          - "*"
         update-types:
           - "patch"
           - "minor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.2
+
+- Update [govuk_tech_docs.gemspec](govuk_tech_docs.gemspec) to only run `npm` if `npm` is installed.  Allows gem versions scans to complete properly.
+
 ## 6.2.1
 
 - [Fix comments in code blocks being hard to read](https://github.com/alphagov/tech-docs-gem/pull/477) 

--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -4,11 +4,17 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "govuk_tech_docs/version"
 
-`npm ci`
-abort "npm ci failed" unless $CHILD_STATUS.success?
-
-unless File.exist?("node_modules/govuk-frontend/dist/govuk/_base.scss")
-  abort "govuk-frontend npm package not installed"
+# npm is not necessarily expected in a gemspec, this makes a big assumption about the environment
+# Additionally, for actions such as evaluating the gemspec (e.g. for vulnerability patching) we do not actaully want npm packages
+# We will move these sections into specific rake tasks when we get a chance
+if system("which npm > /dev/null 2>&1")
+  `npm ci`
+  abort "npm ci failed to run" unless $CHILD_STATUS.success?
+  unless File.exist?("node_modules/govuk-frontend/dist/govuk/_base.scss")
+    abort "govuk-frontend and other npm packages not installed"
+  end
+else
+  warn "npm is not available, no assets will be generated.  If you did not expect this please confirm your environment settings."
 end
 
 Gem::Specification.new do |spec|

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.2.1".freeze
+  VERSION = "6.2.2".freeze
 end


### PR DESCRIPTION
## Proposed changes

The `.gemspec` file contains an `npm` call which is used to import and set up node modules (such as gov.uk frontend).  If the environment does not have npm installed or available, then the gem fails to build.

This is causing issues with dependabot being able to evaluate the gemspec.

### What changed

The call to `npm ci` now checks that there is an `npm` library available

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- Fixes #
- Relates to https://github.com/alphagov/tech-docs-gem/network/updates/3075469/jobs


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed