### PR TITLE
Support non-JSON response content types in OpenAPI renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.4
+
+- Support non-JSON response content types in OpenAPI renderer.
+
 ## 6.2.3
 
 - [Fix TOC sidebar not scrolling to active item on page load](https://github.com/alphagov/tech-docs-gem/pull/480)

--- a/example/source/pets.yml
+++ b/example/source/pets.yml
@@ -33,6 +33,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Pets"
+            text/plain:
+              schema:
+                type: string
+              example: "1: Fido, 2: Buddy, 3: Max"
         default:
           description: unexpected error
           content:

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -58,10 +58,12 @@ module GovukTechDocs
         operations = get_operations(@document.paths[text])
         schemas = operations.flat_map do |_, operation|
           operation.responses.inject([]) do |memo, (_, response)|
-            response.content.values.inject(memo) do |memo, media_type|
+            next memo unless response.content
+
+            response.content.values.inject(memo) do |inner_memo, media_type|
               schema = media_type.schema
-              memo << schema.name if schema.name
-              memo + schemas_from_schema(schema)
+              inner_memo << schema.name if schema.name
+              inner_memo + schemas_from_schema(schema)
             end
           end
         end
@@ -128,7 +130,6 @@ module GovukTechDocs
           when "object"
             schema_properties(schema.items || schema)
           when "array"
-#             schema.example || (schema.items ? [schema_properties(schema.items)] : [])
             schema.items ? [schema_properties(schema.items)] : []
           else
             schema.example || schema.type

--- a/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
+++ b/lib/govuk_tech_docs/api_reference/api_reference_renderer.rb
@@ -58,12 +58,11 @@ module GovukTechDocs
         operations = get_operations(@document.paths[text])
         schemas = operations.flat_map do |_, operation|
           operation.responses.inject([]) do |memo, (_, response)|
-            next memo unless response.content["application/json"]
-
-            schema = response.content["application/json"].schema
-
-            memo << schema.name if schema.name
-            memo + schemas_from_schema(schema)
+            response.content.values.inject(memo) do |memo, media_type|
+              schema = media_type.schema
+              memo << schema.name if schema.name
+              memo + schemas_from_schema(schema)
+            end
           end
         end
 
@@ -129,6 +128,7 @@ module GovukTechDocs
           when "object"
             schema_properties(schema.items || schema)
           when "array"
+#             schema.example || (schema.items ? [schema_properties(schema.items)] : [])
             schema.items ? [schema_properties(schema.items)] : []
           else
             schema.example || schema.type

--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -10,21 +10,23 @@
 <td><%= key %></td>
 <td>
 <%= render_markdown(response.description) %>
-<% if response.content['application/json']
-if response.content['application/json']["example"]
-  request_body = json_prettyprint(response.content['application/json']["example"])
+<% response.content.each do |content_type, media_type| %>
+<% request_body = nil
+if media_type["example"]
+  request_body = json_prettyprint(media_type["example"])
 else
-  request_body = json_output(response.content['application/json'].schema)
-end
+  request_body = json_output(media_type.schema)
 end %>
 <% if !request_body.blank? %>
+<p><em><%= content_type %></em></p>
 <pre><code><%= request_body %></code></pre>
+<% end %>
 <% end %>
 </td>
 <td>
-<%= if response.content['application/json']
-  get_schema_link(response.content['application/json'].schema)
-end %>
+<% response.content.each do |content_type, media_type| %>
+<%= get_schema_link(media_type.schema) %>
+<% end %>
 </td>
 </tr>
 <% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -24,7 +24,7 @@ elsif media_type["example"]
 end %>
 <% if !request_body.blank? %>
 <p><em><%= content_type %></em></p>
-<pre><code><%= request_body %></code></pre>
+<pre><code><%= ERB::Util.html_escape(request_body) %></code></pre>
 <% end %>
 <% end %>
 <% end %>

--- a/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
+++ b/lib/govuk_tech_docs/api_reference/templates/responses.html.erb
@@ -10,22 +10,30 @@
 <td><%= key %></td>
 <td>
 <%= render_markdown(response.description) %>
+<% if response.content %>
 <% response.content.each do |content_type, media_type| %>
 <% request_body = nil
-if media_type["example"]
-  request_body = json_prettyprint(media_type["example"])
-else
-  request_body = json_output(media_type.schema)
+if content_type.include?("json")
+  if media_type["example"]
+    request_body = json_prettyprint(media_type["example"])
+  else
+    request_body = json_output(media_type.schema)
+  end
+elsif media_type["example"]
+  request_body = media_type["example"].to_s
 end %>
 <% if !request_body.blank? %>
 <p><em><%= content_type %></em></p>
 <pre><code><%= request_body %></code></pre>
 <% end %>
 <% end %>
+<% end %>
 </td>
 <td>
+<% if response.content %>
 <% response.content.each do |content_type, media_type| %>
 <%= get_schema_link(media_type.schema) %>
+<% end %>
 <% end %>
 </td>
 </tr>

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.2.3".freeze
+  VERSION = "6.2.4".freeze
 end

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -3,23 +3,25 @@ require "capybara/rspec"
 require "govuk_tech_docs/api_reference/api_reference_renderer"
 
 RSpec.describe GovukTechDocs::ApiReference::Renderer do
+  before(:each) do
+    @spec = {
+      "openapi": "3.0.0",
+      "info": {
+        "title": "title",
+        "version": "0.0.1",
+        "description": "# This is a header\n\nAnd a piece of _text_",
+      },
+      "paths": {},
+      "components": { "schemas": {} },
+    }
+    @app = double("Middleman::Application")
+    @config_context = double("Middleman::ConfigContext")
+    allow(@app).to receive(:config_context).and_return @config_context
+    allow(@config_context).to receive(:app).and_return @app
+    allow(@app).to receive(:api) { |arg| arg }
+  end
+
   describe ".api_full" do
-    before(:each) do
-      @spec = {
-        "openapi": "3.0.0",
-        "info": {
-          "title": "title",
-          "version": "0.0.1",
-          "description": "# This is a header\n\nAnd a piece of _text_",
-        },
-        "paths": {},
-      }
-      @app = double("Middleman::Application")
-      @config_context = double("Middleman::ConfigContext")
-      allow(@app).to receive(:config_context).and_return @config_context
-      allow(@config_context).to receive(:app).and_return @app
-      allow(@app).to receive(:api) { |arg| arg }
-    end
 
     it "renders the description" do
       document = Openapi3Parser.load(@spec)
@@ -77,6 +79,129 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
       expect(rendered).to have_css("div#server-list>a", text: "https://dev.example.com")
       expect(rendered).to have_css("div#server-list>p>strong", text: "Development")
       expect(rendered).to have_css("div#server-list>p>strong>p>em", text: "Development")
+    end
+  end
+
+  describe "response content types" do
+    it "renders a response with no content" do
+      @spec[:paths] = {
+        "/things": {
+          "post": {
+            "summary": "Create a thing",
+            "responses": {
+              "201": { "description": "Created" },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      expect { render.api_full(document.info, document.servers) }.not_to raise_error
+    end
+
+    it "renders a JSON response body from schema" do
+      @spec[:components] = { "schemas": { "Thing": { "properties": { "id": { "type": "integer" } } } } }
+      @spec[:paths] = {
+        "/things": {
+          "get": {
+            "summary": "Get things",
+            "responses": {
+              "200": {
+                "description": "OK",
+                "content": {
+                  "application/json": { "schema": { "$ref": "#/components/schemas/Thing" } },
+                },
+              },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = Capybara::Node::Simple.new(render.api_full(document.info, document.servers))
+
+      expect(rendered).to have_css("em", text: "application/json")
+      expect(rendered).to have_css("pre code", text: /"id"/)
+    end
+
+    it "renders multiple content types" do
+      @spec[:components] = { "schemas": { "Thing": { "properties": { "id": { "type": "integer" } } } } }
+      @spec[:paths] = {
+        "/things": {
+          "get": {
+            "summary": "Get things",
+            "responses": {
+              "200": {
+                "description": "OK",
+                "content": {
+                  "application/json": { "schema": { "$ref": "#/components/schemas/Thing" } },
+                  "text/plain": { "schema": { "type": "string" }, "example": "hello" },
+                },
+              },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = Capybara::Node::Simple.new(render.api_full(document.info, document.servers))
+
+      expect(rendered).to have_css("em", text: "application/json")
+      expect(rendered).to have_css("pre code", text: /"id"/)
+      expect(rendered).to have_css("em", text: "text/plain")
+      expect(rendered).to have_css("pre code", text: "hello")
+    end
+
+    it "renders non-JSON example as plain text" do
+      @spec[:paths] = {
+        "/things": {
+          "get": {
+            "summary": "Get things",
+            "responses": {
+              "200": {
+                "description": "OK",
+                "content": {
+                  "text/plain": { "schema": { "type": "string" }, "example": "plain text response" },
+                },
+              },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = Capybara::Node::Simple.new(render.api_full(document.info, document.servers))
+
+      expect(rendered).to have_css("em", text: "text/plain")
+      expect(rendered).to have_css("pre code", text: "plain text response")
+    end
+
+    it "does not render non-JSON content without an example" do
+      @spec[:paths] = {
+        "/things": {
+          "get": {
+            "summary": "Get things",
+            "responses": {
+              "200": {
+                "description": "OK",
+                "content": {
+                  "application/octet-stream": { "schema": { "type": "string", "format": "binary" } },
+                },
+              },
+            },
+          },
+        },
+      }
+      document = Openapi3Parser.load(@spec)
+
+      render = described_class.new(@app, document)
+      rendered = Capybara::Node::Simple.new(render.api_full(document.info, document.servers))
+
+      expect(rendered).not_to have_css("pre code")
     end
   end
 end

--- a/spec/api_reference/renderer_spec.rb
+++ b/spec/api_reference/renderer_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe GovukTechDocs::ApiReference::Renderer do
   end
 
   describe ".api_full" do
-
     it "renders the description" do
       document = Openapi3Parser.load(@spec)
 

--- a/spec/features/api_reference_spec.rb
+++ b/spec/features/api_reference_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe "OpenAPI reference" do
     expect(page).to have_css("table", text: /\b(How many items to return at one time)\b/)
     # Link to schema
     expect(page).to have_css('table a[href="#schema-error"]')
+    # Multiple content types rendered
+    expect(page).to have_css("em", text: "application/json")
+    expect(page).to have_css("em", text: "text/plain")
+    expect(page).to have_css("pre code", text: "1: Fido, 2: Buddy, 3: Max")
   end
 
   def then_there_is_correct_api_schema_content


### PR DESCRIPTION
## Proposed changes

### What changed
Added support for non-JSON response content types in the OpenAPI renderer. Previously, only `application/json` responses were rendered. Now all content types defined in a response are displayed, with JSON content pretty-printed and non-JSON content rendered as plain text when an example is provided.

## Related issue or tracking reference

[DCMAW-20558](https://govukverify.atlassian.net/browse/DCMAW-20558)

Related PR: https://github.com/govuk-one-login/mobile-wallet-tech-docs/pull/249

## Screenshots or examples (if relevant)

Rendered example OpenAPI spec with multiple and also non-JSON content types:

<img width="1000" height="1421" alt="Screenshot 2026-05-28 at 14 38 34" src="https://github.com/user-attachments/assets/d33e144f-e8b3-460c-98d2-a77b0385c1d8" />

Rendered [Wallet Tech Docs](https://github.com/govuk-one-login/mobile-wallet-tech-docs) OpenAPI spec with content type `application/statuslist+jwt`  and `application/vc+jwt`:

<img width="1128" height="1037" alt="Screenshot 2026-05-28 at 16 28 29" src="https://github.com/user-attachments/assets/617c94db-6250-4cd9-b475-d519eafa81a5" />
<img width="1128" height="1140" alt="Screenshot 2026-05-28 at 16 28 20" src="https://github.com/user-attachments/assets/f1d4ad43-e176-4e18-812d-942d8192ed75" />

## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [ ] you have updated documentation if needed

[DCMAW-20558]: https://govukverify.atlassian.net/browse/DCMAW-20558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ