### PR TITLE
[Bug]: whitespace on long pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 Gemfile.lock
 node_modules
 documentation/build/
+govuk-page-template.html

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@
 Gemfile.lock
 node_modules
 documentation/build/
-govuk-page-template.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+- Bugfix - fix page layout structure to remove whitespace on short pages  
+
 ## 6.3.0.beta
 
 - Add `exe/tech_docs_jobs` to allow executable `Rake` commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,7 @@ You can see more detail about this issue at [#323: Fix XSS vulnerability on sear
 
 There are some steps you should follow as the Technical Documentation Template (TDT) now uses GOV.UK Frontend 4.4.1.
 
-1. Update your documentation site to use the latest template version. You can [follow the TDT guidance on using the latest template version](https://tdt-documentation.london.cloudapps.digital/maintain_project/use_latest_template/).
+1. Update your documentation site to use the latest template version. You can [follow the TDT guidance on using the latest template version](https://alphagov.github.io/tech-docs-gem/maintain_project/use_latest_template/).
 2. Check your documentation site displays correctly. If your site does not display correctly, you can refer to the [GOV.UK Frontend release notes](https://github.com/alphagov/govuk-frontend/releases/) for more information, or [contact the GOV.UK Design System team](https://design-system.service.gov.uk/get-in-touch/).
 
 ### Fixes
@@ -248,7 +248,7 @@ There are some steps you should follow as the Technical Documentation Template (
 
 ### New features
 
-You can now [configure your Tech Docs Template (TDT) to build your documentation site to use relative links to pages and assets](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#build-your-site-using-relative-links).
+You can now [configure your Tech Docs Template (TDT) to build your documentation site to use relative links to pages and assets](https://alphagov.github.io/tech-docs-gem/configure_project/global_configuration/#build-your-site-using-relative-links).
 
 Thanks [@eddgrant](https://github.com/eddgrant) for contributing this feature and the associated fixes.
 
@@ -260,7 +260,7 @@ This change was introduced in [pull request #291: Support sites deployed on path
 
 There are some steps you should follow as the Technical Documentation Template (TDT) now uses GOV.UK Frontend 4.0.0.
 
-1. Update your documentation site to use the latest template version. You can [follow the TDT guidance on using the latest template version](https://tdt-documentation.london.cloudapps.digital/maintain_project/use_latest_template/).
+1. Update your documentation site to use the latest template version. You can [follow the TDT guidance on using the latest template version](https://alphagov.github.io/tech-docs-gem/maintain_project/use_latest_template/).
 2. Check your documentation site displays correctly. If your site does not display correctly, you can refer to the [GOV.UK Frontend 4.0.0 release note](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0) for more information.
 
 ## 3.0.1
@@ -469,7 +469,7 @@ Fixes bug where search results disappear when opening results in a new tab, maki
 
 Adds a `show_expiry` config option to allow you to choose whether to show the review due date and expired banner from your pages. Find out more about the [page expiry and review feature][expiry].
 
-[expiry]: https://tdt-documentation.london.cloudapps.digital/page-expiry.html#page-expiry-and-review
+[expiry]: https://alphagov.github.io/tech-docs-gem/page-expiry.html#page-expiry-and-review
 
 ## 1.8.1
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the [Tech Docs Template documentation][tdt-docs].
 
 Everybody who uses this project is encouraged to contribute.
 
-Find out how to [contribute](https://tdt-documentation.london.cloudapps.digital/support/#contribute).
+Find out how to [contribute](https://alphagov.github.io/tech-docs-gem/support/#contribute).
 
 ## Rake tasks
 
@@ -133,7 +133,7 @@ gem 'govuk_tech_docs', path: '../tech-docs-gem'
 ```
 
 To preview your documentation changes locally, see
-the [Tech Docs Template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+the [Tech Docs Template documentation on previewing your documentation](https://alphagov.github.io/tech-docs-gem/create_project/preview/#preview-your-documentation).
 
 If you experience [the FFI gem issue for Mojave users](https://github.com/alphagov/tech-docs-gem/issues/254), you should
 refer to this [list of possible fixes](#issue-with-ffi-on-osx-mohave).
@@ -154,7 +154,7 @@ If you experience [the FFI gem issue for Mojave users](https://github.com/alphag
 refer to this [list of possible fixes](#issue-with-ffi-on-osx-mohave).
 
 For more information on previewing your documentation locally, see
-the [Tech Docs template documentation on previewing your documentation](https://tdt-documentation.london.cloudapps.digital/create_project/preview/#preview-your-documentation).
+the [Tech Docs template documentation on previewing your documentation](https://alphagov.github.io/tech-docs-gem/create_project/preview/#preview-your-documentation).
 
 ## Tests
 
@@ -237,7 +237,7 @@ licence.
 
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 
-[tdt-docs]: https://github.com/alphagov/tdt-documentation/
+[tdt-docs]: https://alphagov.github.io/tech-docs-gem/
 
 [tdt-template]: https://github.com/alphagov/tech-docs-template
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -17,7 +17,7 @@ bundle exec middleman server
 
 ## Publishing changes
 
-GitHub Actions automatically publishes changes merged into the main branch of this repository to [https://alphagov.github.io/tech-docs-gem/](https://alphagov.github.io/tdt-documentation/).
+GitHub Actions automatically publishes changes merged into the main branch of this repository to [https://alphagov.github.io/tech-docs-gem/](https://alphagov.github.io/tech-docs-gem/).
 
 ## Code of conduct
 

--- a/documentation/config/tech-docs.yml
+++ b/documentation/config/tech-docs.yml
@@ -1,10 +1,10 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://alphagov.github.io/tdt-documentation
+host: https://alphagov.github.io/tech-docs-gem
 
 # Header-related options
 show_govuk_logo: false
 service_name: Tech docs template
-service_link: https://alphagov.github.io/tdt-documentation
+service_link: https://alphagov.github.io/tech-docs-gem
 phase: Beta
 
 # Uncomment if you do not want to activate the GOV.UK Design System component extension

--- a/documentation/source/accessibility/index.html.md.erb
+++ b/documentation/source/accessibility/index.html.md.erb
@@ -11,7 +11,7 @@ The GOV.UK Technical Documentation Template and its documentation are maintained
 
 ## Accessibility statement for the Technical Documentation Template documentation website
 
-This accessibility statement applies to the documentation at [https://tdt-documentation.london.cloudapps.digital/](https://tdt-documentation.london.cloudapps.digital/).
+This accessibility statement applies to the documentation at [https://alphagov.github.io/tech-docs-gem](https://alphagov.github.io/tech-docs-gem/).
 
 This website is run by GDS. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/documentation/source/support/index.html.md.erb
+++ b/documentation/source/support/index.html.md.erb
@@ -21,9 +21,8 @@ We welcome contributions to the Technical Documentation Template.
 
 You can create an issue or pull request in the following GitHub repos:
 
-- [alphagov/tech-docs-gem][tech-docs-gem]
+- [alphagov/tech-docs-gem][tech-docs-gem] - for technical and documentation issues
 - [alphagov/tech-docs-template][tech-docs-template]
-- [alphagov/tdt-documentation](https://github.com/alphagov/tdt-documentation) - for this documentation
 
 You should check and document your pull request before you submit it.
 

--- a/lib/source/layouts/_footer.erb
+++ b/lib/source/layouts/_footer.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer app-footer" role="contentinfo">
+<div class="govuk-footer app-footer" role="contentinfo">
   <% if config[:tech_docs][:show_govuk_logo] %>
   <svg focusable="false" role="presentation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 60" height="30" width="32" fill="currentcolor" class="govuk-footer__crown">
     <g>
@@ -57,4 +57,4 @@
       >© Crown copyright</a>
     </div>
   </div>
-</footer>
+</div>

--- a/lib/source/layouts/_header.erb
+++ b/lib/source/layouts/_header.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
+<div class="govuk-header app-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-header__container--full-width">
     <div class="govuk-header__logo">
       <% if config[:tech_docs][:service_link] %>
@@ -46,4 +46,4 @@
       <% end %>
     </div>
   </div>
-</header>
+</div>

--- a/lib/source/layouts/_service_navigation.erb
+++ b/lib/source/layouts/_service_navigation.erb
@@ -1,7 +1,4 @@
-<% if config[:tech_docs][:header_links] %>
-<div class="govuk-service-navigation app-pane__navigation"
-  data-module="govuk-service-navigation">
-  <div class="govuk-width-container">
+ <div class="govuk-width-container">
     <div class="govuk-service-navigation__container">
       <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
         <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden aria-hidden="true">
@@ -23,5 +20,3 @@
       </nav>
     </div>
   </div>
-</div>
-<% end %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -50,13 +50,19 @@
 
   <body class="govuk-template__body">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    <header class="govuk-template__header app-header" role="banner" data-module="govuk-header">
+      <%= partial 'layouts/header' %>
+    </header>
+    <% if config[:tech_docs][:header_links] %>
+      <div class="govuk-service-navigation app-pane__navigation" data-module="govuk-service-navigation">
+        <%= partial 'layouts/service_navigation' %>
+      </div>
+    <% end %>
 
     <div class="app-pane">
       <%= partial 'layouts/cookie_banner' %>
       <div class="app-pane__header toc-open-disabled">
         <a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-        <%= partial 'layouts/header' %>
-        <%= partial 'layouts/service_navigation' %>
       </div>
 
       <% if content_for? :sidebar %>
@@ -95,11 +101,13 @@
               </ul>
             <% end %>
           </aside>
-
-          <%= partial "layouts/footer" %>
         </div>
       </div>
     </div>
+
+    <footer class="govuk-template__footer">
+      <%= partial "layouts/footer" %>
+    </footer>
 
     <%= partial 'layouts/analytics' %>
     <%= javascript_include_tag :govuk_frontend, :type => "module" %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -59,7 +59,7 @@
       </div>
     <% end %>
 
-    <div class="app-pane">
+
       <%= partial 'layouts/cookie_banner' %>
       <div class="app-pane__header toc-open-disabled">
         <a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
@@ -87,7 +87,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled" aria-label="Content">
-          <main id="content" class="technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
+          <main id="content" class="govuk-main-wrapper technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
             <%= yield %>
             <%= partial "layouts/page_review" %>
           </main>
@@ -103,7 +103,7 @@
           </aside>
         </div>
       </div>
-    </div>
+
 
     <footer class="govuk-template__footer">
       <%= partial "layouts/footer" %>


### PR DESCRIPTION
## Proposed changes

The main page layout in the `tech-docs-gem` is not laid out correctly.  This means that the footer does not fill the space correctly:

<img width="866" height="1441" alt="Screenshot 2026-06-15 at 10 48 52" src="https://github.com/user-attachments/assets/604319c7-12f9-454c-a2d9-8298bd79c771" />


### What changed

- re ordered the template elements so they stack correctly
- removed `.app-pane` from wrapper as this introduces an in-page overflow scroll

Result:

<img width="850" height="1456" alt="Screenshot 2026-06-15 at 10 54 13" src="https://github.com/user-attachments/assets/6f7072b0-0151-4ff0-8e3d-adf0ec27bbd9" />

Tested using Google Dev tools responsive mode and looks unaffected

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- Fixes #
- Relates to [template issue 258](https://github.com/alphagov/tech-docs-template/issues/258)

> If there is no issue, please open one or please explain why one is not needed (for example small maintenance change, routine dependency update).


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed