### PR TITLE
issue 503 enhancement: accessibility horizontal overflow code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.3.1
+
+- Accessibility fix [issue 503](https://github.com/alphagov/tech-docs-gem/issues/503) - add `white-space: pre-wrap;` to [code block styles](lib/assets/stylesheets/modules/_technical-documentation.scss).
+- Bump `govuk-frontend` from 6.2.0 to 6.3.0
+
 ## 6.3.0
 
 - Bugfix [issue 258](https://github.com/alphagov/tech-docs-template/issues/258) - page layout structure to remove whitespace on short pages ([pull request 513](https://github.com/alphagov/tech-docs-gem/pull/513))  

--- a/documentation/Staticfile
+++ b/documentation/Staticfile
@@ -1,4 +1,0 @@
-root: build 
-http_strict_transport_security: true
-http_strict_transport_security_include_subdomains: true
-location_include: includes/*.conf

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -137,6 +137,7 @@
   }
 
   code {
+    white-space: pre-wrap;
     background: $code-01;
     padding: 3px govuk-spacing(1);
     border-radius: 1px;

--- a/lib/assets/stylesheets/modules/_technical-documentation.scss
+++ b/lib/assets/stylesheets/modules/_technical-documentation.scss
@@ -128,6 +128,7 @@
       border: $govuk-focus-width solid govuk-functional-colour(focus-text);
       outline: $govuk-focus-width solid govuk-functional-colour(focus);
     }
+    code {white-space: pre-wrap;}
   }
 
   pre code {
@@ -137,7 +138,6 @@
   }
 
   code {
-    white-space: pre-wrap;
     background: $code-01;
     padding: 3px govuk-spacing(1);
     border-radius: 1px;

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.3.0".freeze
+  VERSION = "6.3.1".freeze
 end


### PR DESCRIPTION
## Proposed changes

### What changed

- added a css style to code blocks to stop horizontal scrolling

## Related issue or tracking reference

- Fixes #503 

> If there is no issue, please open one or please explain why one is not needed (for example small maintenance change, routine dependency update).

## Screenshots or examples (if relevant)

### Before the change:

<img width="846" height="618" alt="Screenshot 2026-07-02 at 12 21 44" src="https://github.com/user-attachments/assets/20e35fd9-8939-4b68-8c37-c9274fce788b" />

<img width="779" height="312" alt="Screenshot 2026-07-02 at 12 21 34" src="https://github.com/user-attachments/assets/30daabd2-1bed-449c-ac5b-d9a8f930054b" />

### After the change
<img width="977" height="532" alt="Screenshot 2026-07-02 at 12 21 08" src="https://github.com/user-attachments/assets/c5c22f35-0bcb-4182-b31d-656fdec73365" />
<img width="869" height="749" alt="Screenshot 2026-07-02 at 12 21 22" src="https://github.com/user-attachments/assets/258528d3-7455-45a1-ae5d-9eecee908b58" />


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed