### PR TITLE
remove gov-wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+## 6.3.1.beta
+
+- [Remove govuk wrapper class](https://github.com/alphagov/tech-docs-gem/pull/530) that introduced extra padding 
 - Update[ template html syntax](https://github.com/alphagov/tech-docs-gem/pull/520) to more closely match gov.uk design template
 - bump govuk-frontend from [6.2.0 to 6.3.0](https://github.com/alphagov/tech-docs-gem/pull/517)
 

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.3.0".freeze
+  VERSION = "6.3.1.beta".freeze
 end

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -85,7 +85,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled" aria-label="Content">
-          <main id="content" class="govuk-main-wrapper technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
+          <main id="content" class="technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
             <%= yield %>
             <%= partial "layouts/page_review" %>
           </main>


### PR DESCRIPTION
## Proposed changes

### What changed

Removed govuk template class that was introducing additional padding

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- [Relates to #](https://gds.slack.com/archives/CACFQBL0Y/p1787060783787739)

> If there is no issue, please open one or please explain why one is not needed (for example small maintenance change, routine dependency update).

## Screenshots or examples (if relevant)

Include screenshots, logs, or rendered output if this change affects layout or behaviour.

## Checklist

Before you request approval you should confirm that:

- [ ] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [ ] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [ ] you have linked this PR to an issue (or explained why none exists)
- [ ] you have updated documentation if needed