### PR TITLE
 use govuk header and footer components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Unreleased changes
 
+## 6.4.0
+
+### Changed
+
+- **potentially breaking**: `enable_govuk_components` has been removed from the config as these are now required for the header and footer.  If you are using this value for custom code or templates you should address this before updating.
+- added config settings:
+  - `product_name`
+  - `headerContainerClasses`
+  - `headerClasses`
+  - `navigationContainerClasses`
+  - `navigationClasses`
+  
+[Check the documentation](https://design-system.service.gov.uk/components/header/) to see if you should add this value into your site.
+
+- updated header and footer layouts to use components
+
 ## 6.3.1.beta
 
 - [Remove govuk wrapper class](https://github.com/alphagov/tech-docs-gem/pull/530) that introduced extra padding 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### Deprecation warning
 
 - `show_govuk_logo:` setting will be removed in v7.x.x in to be replaced by the generic header and custom logo settings
-- `warning_text` custom extension will be removed in v7.x.x.  This was [marked as deprecated on 1st June 2026](https://github.com/alphagov/tech-docs-gem/commit/304230ba9c49759471a9a8f2daa425e37f846364#diff-2a7ef696e418f6044e5b18ae22c9cff4cac18481ae6fd0c1360ef978087b6cc9R8-R9).  You should now use the GOV.UK warning text component. 
+- `warning_text` custom extension will be removed in v7.x.x.  This was [marked as deprecated on 1st June 2026](https://github.com/alphagov/tech-docs-gem/commit/304230ba9c49759471a9a8f2daa425e37f846364#diff-2a7ef696e418f6044e5b18ae22c9cff4cac18481ae6fd0c1360ef978087b6cc9R8-R9).  You should now [use the GOV.UK warning text component](https://alphagov.github.io/tech-docs-gem/write_docs/content/#use-the-gov-uk-design-system). 
 
 
 ## 6.3.1.beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-## 6.4.0
+## 6.5.0
 
 ### Changed
 
@@ -15,6 +15,12 @@
 [Check the documentation](https://design-system.service.gov.uk/components/header/) to see if you should add this value into your site.
 
 - updated header and footer layouts to use components
+
+### Deprecation warning
+
+- `show_govuk_logo:` setting will be removed in v7.x.x in to be replaced by the generic header and custom logo settings
+- `warning_text` custom extension will be removed in v7.x.x.  This was [marked as deprecated on 1st June 2026](https://github.com/alphagov/tech-docs-gem/commit/304230ba9c49759471a9a8f2daa425e37f846364#diff-2a7ef696e418f6044e5b18ae22c9cff4cac18481ae6fd0c1360ef978087b6cc9R8-R9).  You should now use the GOV.UK warning text component. 
+
 
 ## 6.3.1.beta
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,16 @@ refer to this [list of possible fixes](#issue-with-ffi-on-osx-mohave).
 For more information on previewing your documentation locally, see
 the [Tech Docs template documentation on previewing your documentation](https://alphagov.github.io/tech-docs-gem/create_project/preview/#preview-your-documentation).
 
-## Tests
 
-### Ruby tests and linting
+## Linting
+
+You should run the linter before pushing any changes to GitHub to check for errors and correct formatting.  You can run linter jobs for ruby by running `bundle exec rubocop`. If you would like the linter to try and automatically fix any errors use `bundle exec rubocop -a`.  
+
+You can lint javascript files with the command `npm run lint`.  If only want to see the final result and not the full output use `npm run lint --silent`.
+
+You can also use the `Rakefile` job to run both together by running `bundle exec rake lint`.  See the [Rakefile](./Rakefile) for more detail.
+
+### Ruby tests
 
 You can run the Ruby test suite with the following command:
 
@@ -166,28 +173,9 @@ You can run the Ruby test suite with the following command:
 bundle exec rake spec
 ```
 
-To test a specific file include the filepath after `rspec`.
+To test a specific file use Rake's `SPEC` variable and set it to your filepath or directory.  For example `bundle exec rake spec SPEC=spec/govuk_tech_docs/meta_tags_spec.rb`
 
-You can lint the ruby code with the command:
-
-```shell
-bundle exec rubocop
-```
-
-Rubocop can automatically fix some linting issues. If the above command has suggestions that you automatically fix them
-with:
-
-```shell
-bundle exec rubocop -a 
-```
-
-### JavaScript tests and linting
-
-Use this command to run the linting and tests for the JavaScript code:
-
-```sh
-bundle exec rake
-```
+### JavaScript tests
 
 The JavaScript tests use the [Jasmine test framework][jas].
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ the [Tech Docs template documentation on previewing your documentation](https://
 
 You should run the linter before pushing any changes to GitHub to check for errors and correct formatting.  You can run linter jobs for ruby by running `bundle exec rubocop`. If you would like the linter to try and automatically fix any errors use `bundle exec rubocop -a`.  
 
-You can lint javascript files with the command `npm run lint`.  If only want to see the final result and not the full output use `npm run lint --silent`.
+You can lint javascript files with the command `npm run lint`.  If only want to see the final result and not the full output, use `npm run lint --silent`.
 
 You can also use the `Rakefile` job to run both together by running `bundle exec rake lint`.  See the [Rakefile](./Rakefile) for more detail.
 
@@ -173,7 +173,7 @@ You can run the Ruby test suite with the following command:
 bundle exec rake spec
 ```
 
-To test a specific file use Rake's `SPEC` variable and set it to your filepath or directory.  For example `bundle exec rake spec SPEC=spec/govuk_tech_docs/meta_tags_spec.rb`
+To test a specific file, use Rake's `SPEC` variable and set it to your filepath or directory.  For example `bundle exec rake spec SPEC=spec/govuk_tech_docs/meta_tags_spec.rb`
 
 ### JavaScript tests
 

--- a/documentation/config/tech-docs.yml
+++ b/documentation/config/tech-docs.yml
@@ -3,14 +3,12 @@ host: https://alphagov.github.io/tech-docs-gem
 
 # Header-related options
 show_govuk_logo: false
+product_name:
 service_name: Tech docs template
 service_link: https://alphagov.github.io/tech-docs-gem
 phase: Beta
 
-# Uncomment if you do not want to activate the GOV.UK Design System component extension
-enable_govuk_components: true
-
-# Links to show on right-hand-side of header
+# Links to show on service navigation below header
 header_links:
   Template: https://github.com/alphagov/tech-docs-template
   Ruby gem: https://github.com/alphagov/tech-docs-gem

--- a/documentation/config/tech-docs.yml
+++ b/documentation/config/tech-docs.yml
@@ -7,16 +7,19 @@ product_name:
 service_name: Tech docs template
 service_link: https://alphagov.github.io/tech-docs-gem
 phase: Beta
-#
-#These can be used to add custom classes to the header and service navigation components. You can find more detail about these on the component documentation at:
+
+
+#These can be used to add custom classes to the GOV.UK header, footer and service navigation components. You can find more detail about these on the component documentation at:
 #https://design-system.service.gov.uk/components/header/
 #https://design-system.service.gov.uk/components/service-navigation/
+#https://design-system.service.gov.uk/components/footer/
 
 headerContainerClasses:
 headerClasses:
 navigationContainerClasses:
 navigationClasses:
-
+footerContainerClasses:
+footerClasses:
 
 # Links to show on service navigation below header
 header_links:

--- a/documentation/config/tech-docs.yml
+++ b/documentation/config/tech-docs.yml
@@ -7,6 +7,16 @@ product_name:
 service_name: Tech docs template
 service_link: https://alphagov.github.io/tech-docs-gem
 phase: Beta
+#
+#These can be used to add custom classes to the header and service navigation components. You can find more detail about these on the component documentation at:
+#https://design-system.service.gov.uk/components/header/
+#https://design-system.service.gov.uk/components/service-navigation/
+
+headerContainerClasses:
+headerClasses:
+navigationContainerClasses:
+navigationClasses:
+
 
 # Links to show on service navigation below header
 header_links:

--- a/documentation/source/configure_project/global_configuration/index.html.md.erb
+++ b/documentation/source/configure_project/global_configuration/index.html.md.erb
@@ -16,10 +16,23 @@ When you create your documentation project, the template creates a `tech-docs.ym
 host:
 
 # Header-related options
+product_name: GOV.UK Product
 show_govuk_logo: true
 service_name: My First Service
 service_link: https://www.larry-the-cat.service.gov.uk
 phase: Beta
+
+#These can be used to add custom classes to the GOV.UK header, footer and service navigation components. You can find more detail about these on the component documentation at:
+#https://design-system.service.gov.uk/components/header/
+#https://design-system.service.gov.uk/components/service-navigation/
+#https://design-system.service.gov.uk/components/footer/
+
+headerContainerClasses:
+headerClasses:
+navigationContainerClasses:
+navigationClasses:
+footerContainerClasses:
+footerClasses:
 
 # Links to show on right-hand-side of header
 header_links:
@@ -51,15 +64,17 @@ prevent_indexing: false
 show_contribution_banner: true
 github_repo: alphagov/YOUR_REPO
 github_branch: main
+
 ```
 
-<%= warning_text('All of these settings are optional. However, you should enable or disable settings to increase the usability of your documentation or because of best practice.') %>
+<%= govukWarningText({text: "All of these settings are optional. However, you should enable or disable settings to increase the usability of your documentation or because of best practice.", iconFallbackText: "Warning"}) %>
 
 You must wrap a value in quotes if it contains a colon, unless the value is a URL. For example:
 
 ```
 description: "GDS: My amazing documentation"
 ```
+
 
 If you are not sure which settings to enable or disable, [contact the Government Digital Service (GDS) technical writing team][contact-email].
 
@@ -85,6 +100,18 @@ Enables and disables the GOV.UK crown logo in the top left corner of the site. D
 show_govuk_logo: true
 ```
 
+<%= govukWarningText({text: "This setting is deprecated and will be replaced in version 7 by the generic header and custom logo options.", iconFallbackText: "Warning"}) %>
+
+### product_name
+
+Used for the `productName` value in the [GOV.UK header component](https://design-system.service.gov.uk/components/header/).  It is used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use the Service navigation component.
+
+```yaml
+product_name: "Great new product"
+```
+
+
+
 ### service_name
 
 Defines the service name in the header. Defaults to "My First Service" if you do not define it when creating your project.
@@ -109,6 +136,34 @@ Defines the phase of the service that the documentation is attached to. Defaults
 phase: "Beta"
 ```
 
+### Header and footer custom styles
+
+If you have set `show_gouk_logo` to `true` the header, service navigation and footer will use GOV.UK components.
+
+#### Container classes
+
+Classes for the container, useful if you want to make the header fixed width. The container settings you can configure are:
+
+- `headerContainerClasses:`
+- `navigationContainerClasses:`
+- `footerContainerClasses:`
+
+```yaml
+headerContainerClasses: ".my-custom-container-style"
+```
+
+You can add custom classes to the components in the same way.  The settings you can configure are:
+
+- `headerClasses:`
+- `navigationClasses:`
+- `footerClasses:`
+
+```yaml
+footerClasses: ".my-custom-footer-style"
+```
+
+There is more detail on the [GOV.UK Design System](https://design-system.service.gov.uk/components) documentation site.
+
 ### Govuk components
 
 The `tech-docs-gem` contains a custom extension to allow you to use [GOV.UK Design System components](https://design-system.service.gov.uk/components).  You can include these in your content by creating a `ruby` codeblock, and calling the component as described in the GOV.UK Design System documentation.  For example, you can include a [GOV.UK Button](https://design-system.service.gov.uk/components/button/):
@@ -120,7 +175,7 @@ The `tech-docs-gem` contains a custom extension to allow you to use [GOV.UK Desi
 This would be a short introduction, but now we need a button!
 
 
-<%%= govukButton({
+<%= govukButton({
   text: "Click me!"
 }) %>
 

--- a/documentation/source/configure_project/global_configuration/index.html.md.erb
+++ b/documentation/source/configure_project/global_configuration/index.html.md.erb
@@ -149,7 +149,7 @@ Classes for the container, useful if you want to make the header fixed width. Th
 - `footerContainerClasses:`
 
 ```yaml
-headerContainerClasses: ".my-custom-container-style"
+headerContainerClasses: "my-custom-container-style my-additional-styles"
 ```
 
 You can add custom classes to the components in the same way.  The settings you can configure are:
@@ -159,7 +159,7 @@ You can add custom classes to the components in the same way.  The settings you 
 - `footerClasses:`
 
 ```yaml
-footerClasses: ".my-custom-footer-style"
+footerClasses: "my-custom-footer-style"
 ```
 
 There is more detail on the [GOV.UK Design System](https://design-system.service.gov.uk/components) documentation site.

--- a/documentation/source/configure_project/global_configuration/index.html.md.erb
+++ b/documentation/source/configure_project/global_configuration/index.html.md.erb
@@ -138,7 +138,7 @@ phase: "Beta"
 
 ### Header and footer custom styles
 
-If you have set `show_gouk_logo` to `true` the header, service navigation and footer will use GOV.UK components.
+If you have set `show_gouk_logo` to `true`, the header, service navigation and footer will use GOV.UK components.
 
 #### Container classes
 

--- a/documentation/source/configure_project/global_configuration/index.html.md.erb
+++ b/documentation/source/configure_project/global_configuration/index.html.md.erb
@@ -21,9 +21,6 @@ service_name: My First Service
 service_link: https://www.larry-the-cat.service.gov.uk
 phase: Beta
 
-# Uncomment if you do not want to activate the GOV.UK Design System component extension 
-# enable_govuk_components: false
-
 # Links to show on right-hand-side of header
 header_links:
   About: https://www.larry-the-cat.service.gov.uk
@@ -112,7 +109,7 @@ Defines the phase of the service that the documentation is attached to. Defaults
 phase: "Beta"
 ```
 
-### enable_govuk_components
+### Govuk components
 
 The `tech-docs-gem` contains a custom extension to allow you to use [GOV.UK Design System components](https://design-system.service.gov.uk/components).  You can include these in your content by creating a `ruby` codeblock, and calling the component as described in the GOV.UK Design System documentation.  For example, you can include a [GOV.UK Button](https://design-system.service.gov.uk/components/button/):
 

--- a/documentation/source/write_docs/content/index.html.md.erb
+++ b/documentation/source/write_docs/content/index.html.md.erb
@@ -117,7 +117,7 @@ This warning text format is consistent with the [GOV.UK Design System warning te
 To insert a warning, use the following:
 
 ```ruby
-<%%= warning_text('insert warning text here') %>
+<%= warning_text('insert warning text here') %>
 ```
 
 ## Use the GOV.UK Design System

--- a/documentation/source/write_docs/content/index.html.md.erb
+++ b/documentation/source/write_docs/content/index.html.md.erb
@@ -110,6 +110,8 @@ You must include alt text for an image if the image has not been explained in su
 
 ## Insert a warning
 
+<%= govukWarningText({text: "This setting is deprecated and will be removed in version 7.  You should use the GOV.UK warning text component.", iconFallbackText: "Warning"}) %>
+
 Use the warning text component when you need to warn users about something important, such as legal consequences of an action, or lack of action, that they might take.
 
 This warning text format is consistent with the [GOV.UK Design System warning text][design-system].
@@ -120,9 +122,23 @@ To insert a warning, use the following:
 <%= warning_text('insert warning text here') %>
 ```
 
+
 ## Use the GOV.UK Design System
 
-Use [GOV.UK Design System](https://design-system.service.gov.uk/) elements in your documentation to ensure your content complies with accessibility regulations.
+Use [GOV.UK Design System](https://design-system.service.gov.uk/) elements in your documentation to ensure your content complies with accessibility regulations.  To use a component from the design system call the component function inside a ruby block.  For example:
+
+```
+<%=
+govukPhaseBanner({
+  tag: {
+    text: "Alpha"
+  },
+  html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback by email</a>.'
+})
+%>
+```
+
+You do not need to import the function using `from "govuk/components/{COMPONENT_NAME}/macro.njk" import {COMPONENT_NAME}`.  The extension will do this automatically.
 
 
 <%= partial "partials/links" %>

--- a/lib/assets/stylesheets/_govuk_tech_docs.scss
+++ b/lib/assets/stylesheets/_govuk_tech_docs.scss
@@ -14,15 +14,7 @@ $govuk-new-link-styles: true;
 @import "govuk/core";
 @import "govuk/objects";
 
-@import "govuk/components/cookie-banner";
-@import "govuk/components/footer";
-@import "govuk/components/header";
-@import "govuk/components/service-navigation";
-@import "govuk/components/inset-text";
-@import "govuk/components/input";
-@import "govuk/components/tag";
-@import "govuk/components/skip-link";
-@import "govuk/components/warning-text";
+@import "govuk/components";
 
 @import "govuk/utilities";
 @import "govuk/overrides";

--- a/lib/govuk_tech_docs.rb
+++ b/lib/govuk_tech_docs.rb
@@ -84,6 +84,7 @@ module GovukTechDocs
     context.activate :unique_identifier
     context.activate :warning_text
     context.activate :api_reference
+    context.activate :custom_method_missing_handler
 
     context.helpers do
       include GovukTechDocs::PathHelpers
@@ -163,10 +164,6 @@ module GovukTechDocs
       end
     else
       context.ignore "search/*"
-    end
-
-    if context.config[:tech_docs][:enable_govuk_components]
-      context.activate :custom_method_missing_handler
     end
   end
 end

--- a/lib/govuk_tech_docs/version.rb
+++ b/lib/govuk_tech_docs/version.rb
@@ -1,3 +1,3 @@
 module GovukTechDocs
-  VERSION = "6.4.0.beta".freeze
+  VERSION = "6.5.0".freeze
 end

--- a/lib/govuk_tech_docs/warning_text_extension.rb
+++ b/lib/govuk_tech_docs/warning_text_extension.rb
@@ -5,8 +5,8 @@ module GovukTechDocs
     end
 
     helpers do
-      warn("This functionality is deprecated and will be removed in a future release. \n You should use the GOV.UK warning text component instead.")
       def warning_text(text)
+        warn("The `warning_text` function will be removed in version 7. You should use the GOV.UK warning text component instead.")
         <<~EOS
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/lib/source/layouts/_govuk_footer.erb
+++ b/lib/source/layouts/_govuk_footer.erb
@@ -1,0 +1,9 @@
+<%=
+
+  govukFooter({
+    containerClasses: config[:tech_docs][:footerContainerClasses] ? config[:tech_docs][:footerContainerClasses] : "govuk-footer__container--full-width",
+    classes: config[:tech_docs][:footerClasses] ? config[:tech_docs][:footerClasses] : "",
+
+  })
+
+%>

--- a/lib/source/layouts/_govuk_header.erb
+++ b/lib/source/layouts/_govuk_header.erb
@@ -9,9 +9,9 @@
 govukHeader({
   homepageUrl: homepage_url || "",
   productName: config[:tech_docs][:product_name] ? config[:tech_docs][:product_name] : "",
-  containerClasses: defined?(headerContainerClasses) ? headerContainerClasses : "",
-  classes: defined?(headerClasses) ? headerClasses : "",
-  attributes: defined?(headerAttributes) ? headerAttributes :  {}
+  containerClasses: config[:tech_docs][:headerContainerClasses] ? config[:tech_docs][:headerContainerClasses] : "govuk-header__container--full-width",
+  classes: config[:tech_docs][:headerClasses] ? config[:tech_docs][:headerClasses] : ""
+
 })
 
 %>

--- a/lib/source/layouts/_govuk_header.erb
+++ b/lib/source/layouts/_govuk_header.erb
@@ -7,10 +7,10 @@
 <%=
 
 govukHeader({
-  url: homepage_url || "",
+  homepageUrl: homepage_url || "",
   productName: config[:tech_docs][:product_name] ? config[:tech_docs][:product_name] : "",
   containerClasses: defined?(headerContainerClasses) ? headerContainerClasses : "",
-  classesClasses: defined?(headerClasses) ? headerClasses : "",
+  classes: defined?(headerClasses) ? headerClasses : "",
   attributes: defined?(headerAttributes) ? headerAttributes :  {}
 })
 

--- a/lib/source/layouts/_govuk_header.erb
+++ b/lib/source/layouts/_govuk_header.erb
@@ -1,0 +1,17 @@
+<%
+  service_link = config[:tech_docs][:service_link]
+  homepage_url = service_link ? get_path_to_resource(config, service_link, current_page) : nil
+
+%>
+
+<%=
+
+govukHeader({
+  url: homepage_url || "",
+  productName: config[:tech_docs][:product_name] ? config[:tech_docs][:product_name] : "",
+  containerClasses: defined?(headerContainerClasses) ? headerContainerClasses : "",
+  classesClasses: defined?(headerClasses) ? headerClasses : "",
+  attributes: defined?(headerAttributes) ? headerAttributes :  {}
+})
+
+%>

--- a/lib/source/layouts/_service_navigation.erb
+++ b/lib/source/layouts/_service_navigation.erb
@@ -1,22 +1,24 @@
- <div class="govuk-width-container">
-    <div class="govuk-service-navigation__container">
-      <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
-        <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden aria-hidden="true">
-          Menu
-        </button>
-        <ul class="govuk-service-navigation__list" id="navigation">
-          <% config[:tech_docs][:header_links].each do |title, path| %>
-            <li class="govuk-service-navigation__item <% if active_page(path) %> govuk-service-navigation__item--active<% end %>">
-              <a class="govuk-service-navigation__link" href="<%= get_path_to_resource config, path, current_page %>"<% if active_page(path) %> aria-current="page"<% end %>>
-              <% if active_page(path) %>
-                <strong class="govuk-service-navigation__active-fallback"><%= title %></strong>
-              <% else %>
-                <%= title %>
-              <% end %>
-              </a>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
-    </div>
-  </div>
+<%
+
+  navigation = []
+  config[:tech_docs][:header_links].each do |title, path|
+    navigation.append << {
+      href: path,
+      text: title,
+      active: active_page(path)
+    }
+  end
+
+%>
+
+
+<%=
+  govukServiceNavigation({
+       navigation: navigation,
+       serviceUrl: config[:tech_docs][:service_link] ,
+       serviceName: config[:tech_docs][:service_name],
+       navigationClasses: defined?(navigationContainerClasses) ? navigationContainerClasses : "",
+       classes: defined?(navigationClasses) ? navigationClasses : "",
+       attributes: defined?(navigationAttributes) ? navigationAttributes :  {}
+  })
+%>

--- a/lib/source/layouts/_service_navigation.erb
+++ b/lib/source/layouts/_service_navigation.erb
@@ -17,8 +17,7 @@
        navigation: navigation,
        serviceUrl: config[:tech_docs][:service_link] ,
        serviceName: config[:tech_docs][:service_name],
-       navigationClasses: defined?(navigationContainerClasses) ? navigationContainerClasses : "",
-       classes: defined?(navigationClasses) ? navigationClasses : "",
-       attributes: defined?(navigationAttributes) ? navigationAttributes :  {}
+       navigationClasses: config[:tech_docs][:navigationContainerClasses] ? config[:tech_docs][:navigationContainerClasses] : "",
+       classes: config[:tech_docs][:navigationClasses] ? config[:tech_docs][:navigationClasses] : ""
   })
 %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -99,7 +99,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled" aria-label="Content">
-          <main id="content" class="govuk-main-wrapper technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
+          <main id="content" class="technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
             <%= yield %>
             <%= partial "layouts/page_review" %>
           </main>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -52,7 +52,19 @@
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
   <!-- .app-header aligns the header component properly with the in page navigation   -->
     <div class="app-header" role="banner" data-module="govuk-header">
-      <%= partial 'layouts/govuk_header' %>
+      <% if config[:tech_docs][:show_govuk_logo] %>
+         <%= partial 'layouts/govuk_header' %>
+      <% else %>
+        <%=
+          # if show govuk_logo is true we can just use the govuk component.
+          # If not we need to fall back temporarily to the old custom header to make sure we don't start
+          # showing logos everywhere, as there is no option in the component to turn it off.  This will be removed once the generic header and branding is in place.
+          # We will raise a deprecation warning to let people know this is imminent
+          warn("You have set show_govuk_logo to false or removed it from your config.  This setting wil be removed in version 7 to be replaced by the generic header and custom logo.  If you rely on this setting for custom code you should review this as soon as possible.")
+        %>
+        <%= partial 'layouts/header' %>
+      <% end %>
+
     </div>
 
     <% if config[:tech_docs][:header_links] %>
@@ -106,7 +118,11 @@
 
 
     <footer class="govuk-template__footer">
-      <%= partial "layouts/govuk_footer" %>
+      <% if config[:tech_docs][:show_govuk_logo] %>
+        <%= partial "layouts/govuk_footer" %>
+      <% else %>
+        <%= partial "layouts/footer" %>
+      <% end %>
     </footer>
 
     <%= partial 'layouts/analytics' %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -116,7 +116,6 @@
         </div>
       </div>
 
-
     <footer class="govuk-template__footer">
       <% if config[:tech_docs][:show_govuk_logo] %>
         <%= partial "layouts/govuk_footer" %>

--- a/lib/source/layouts/core.erb
+++ b/lib/source/layouts/core.erb
@@ -50,9 +50,11 @@
 
   <body class="govuk-template__body">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-    <header class="govuk-template__header app-header">
-      <%= partial 'layouts/header' %>
-    </header>
+  <!-- .app-header aligns the header component properly with the in page navigation   -->
+    <div class="app-header" role="banner" data-module="govuk-header">
+      <%= partial 'layouts/govuk_header' %>
+    </div>
+
     <% if config[:tech_docs][:header_links] %>
         <%= partial 'layouts/service_navigation' %>
     <% end %>
@@ -85,7 +87,7 @@
         <% end %>
 
         <div class="app-pane__content toc-open-disabled" aria-label="Content">
-          <main id="content" class="technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
+          <main id="content" class="govuk-main-wrapper technical-documentation"<% if config[:tech_docs][:enable_anchored_headings] != false %> data-module="anchored-headings"<% end %>>
             <%= yield %>
             <%= partial "layouts/page_review" %>
           </main>
@@ -104,7 +106,7 @@
 
 
     <footer class="govuk-template__footer">
-      <%= partial "layouts/footer" %>
+      <%= partial "layouts/govuk_footer" %>
     </footer>
 
     <%= partial 'layouts/analytics' %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.4.tgz",
+      "integrity": "sha512-JL+CF0GeLHyPWI0rXu7UnxgiuOm9UQWzadi0OYOJNhNO2q6EZElpwlgXkNkfU1PzANDHq3YcwKVZprdvS+BrbQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -40,18 +40,8 @@ RSpec.describe "The tech docs template" do
     then_there_is_a_robots_noindex_metatag
   end
 
-  it "does not use the GOV.UK design system components if the setting is disabled" do
-    when_the_site_is_created_without_govuk_components
-    and_i_visit_the_homepage
-    then_there_is_no_button
-  end
-
   def when_the_site_is_created
     rebuild_site!
-  end
-
-  def when_the_site_is_created_without_govuk_components
-    rebuild_site!(overrides: { "enable_govuk_components" => false })
   end
 
   def and_i_visit_the_homepage
@@ -83,11 +73,6 @@ RSpec.describe "The tech docs template" do
     ].each do |url|
       expect(page).to have_link(nil, href: url)
     end
-  end
-
-  def then_there_is_no_button
-    expect(page).to_not have_content "Click me!"
-    expect(page).to_not have_css "button.govuk-button"
   end
 
   def then_the_page_highlighted_in_the_navigation_is(link_label)

--- a/spec/test-site/config/tech-docs.yml
+++ b/spec/test-site/config/tech-docs.yml
@@ -6,6 +6,11 @@ show_govuk_logo: true
 service_name: My First Service
 service_link: /
 phase: Beta
+product_name:
+headerContainerClasses:
+headerClasses:
+navigationContainerClasses:
+navigationClasses:
 
 # Links to show in service navigation
 header_links:

--- a/spec/test-site/config/tech-docs.yml
+++ b/spec/test-site/config/tech-docs.yml
@@ -1,9 +1,6 @@
 # Host to use for canonical URL generation (without trailing slash)
 host: https://docs.example.com
 
-# Enable GOV.UK Design System nunjucks components (https://design-system.service.gov.uk/components)
-enable_govuk_components: true
-
 # Header-related options
 show_govuk_logo: true
 service_name: My First Service

--- a/spec/test-site/source/index.html.md.erb
+++ b/spec/test-site/source/index.html.md.erb
@@ -18,10 +18,7 @@ To change the title of the page or include additional files you'll need to edit 
 If you want slightly more control, you can always use <strong>HTML</strong>.
 
 For more detail and troubleshooting, take a look at the `README.md` file in the root of this project.
-<% if config[:tech_docs][:enable_govuk_components] %>
 
 <%= govukButton({
   text: "Click me!"
 }) %>
-
-<% end %>


### PR DESCRIPTION
## Proposed changes

### What changed

This change adds the GOV.UK header and footer components into the main template.  This is in preparation for adding in the generic header and cleaner options to turn off gov.uk branding.  This will follow in a future release.

The component settings are controlled by existing values in `config/tech-docs.yml`.

The option to disable GOV.UK components has also been removed from `config/tech-docs.yml` as this will now be required. Have added extra configurations for customising the components:
- headerContainerClasses:
- headerClasses:
- navigationContainerClasses:
- navigationClasses:


## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- Fixes #521 
- Relates to #516 and #493 

## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] GitHub actions all pass
- [x] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed