### PR TITLE
Improved linter job output

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,33 +1,104 @@
 # Rakefile
 require "json"
-require "open3"
+require "timeout" # Built into standard Ruby
 require_relative "./helpers/rake_utils"
 require_relative "./helpers/vale_report"
 
 namespace :lint do
-  # task vale_sync:
-  desc "Run tech-docs-linter to check content against GOV.UK style guide."
+  desc "Run linter to check content against GOV.UK style guide."
   task :vale, [:target, :clean_build, :full_output] do |_t, args|
     args.with_defaults(target: "./build", clean_build: "true", full_output: "true")
 
-    sh "bundle exec vale sync --config='#{vale_config_path}'"
+    # sh "bundle exec vale sync --config='#{vale_config_path}'"
+    Rake::Task["middleman:build"].invoke if args.clean_build == "true"
 
-    if args.clean_build == "true"
-      Rake::Task["middleman:build"].invoke
+    files = Dir.glob("#{args.target}/**/*.{html,md}")
+    puts "Running Vale against #{files.count} files...\n\n"
+
+    combined_json = {}
+
+    files.each do |file|
+      print "Linting #{file}... "
+
+      file_output = ""
+
+      # IO.popen runs the command and exposes the Process ID (PID)
+      IO.popen(["vale", "--config=#{vale_config_path}", "--output=JSON", file]) do |io|
+        begin
+          # If a file takes longer than 10 seconds, raise a timeout
+          Timeout.timeout(10) do
+            file_output = io.read
+          end
+          # If we reach here, it finished safely
+          puts "\e[32mDone\e[0m"
+        rescue Timeout::Error
+          # The regex hung. Send a SIGKILL to the Vale process to stop it chewing CPU
+          Process.kill("KILL", io.pid)
+          puts "\e[31mHUNG (Skipped due to timeout)\e[0m" # Red text
+        end
+      end
+
+      # Merge JSON only if we got a valid response (ignores timeouts)
+      unless file_output.strip.empty?
+        parsed_output = JSON.parse(file_output)
+        combined_json.merge!(parsed_output) unless parsed_output.empty?
+      end
     end
 
-    stdout, = Open3.capture3("vale --config='#{vale_config_path}' --output=JSON #{args.target}")
+    puts "\nGenerating report..."
 
-    linter_report = ValeLinterReport.new(stdout)
+    linter_report = ValeLinterReport.new(combined_json.to_json)
     linter_report.format_linter_output
-    if args.full_output == "true"
-      puts linter_report.get_linter_full_report
-    end
+
+    puts linter_report.get_linter_full_report if args.full_output == "true"
     puts linter_report.get_linter_summary_report
 
-    # finish with a Ci friendly json string
     linter_report.linter_summary_report_json
-    # Always exit 0 so individual project pipelines can evaluate the data themselves
     exit 0
   end
+
+  desc "Debug Vale to find which rule hangs on a specific file."
+  task :debug do
+
+    style_prefix = 'tech-writing-style-guide'
+    target_file = './build/search/index.html'
+
+    # ADD YOUR RULE NAMES HERE (without the style prefix or .yml extension)
+    rules = [
+      "acronyms", "brackets-in-headings", "common-misspellings","H4", "H5", "H6", "headings-length", "multiple-h1-tags",
+      "sentence-length","terminal-punctuation","words-to-avoid","words-to-avoid-unless",
+      "skipped-heading-levels",
+      "consecutive-headings",
+      "headings-with-no-content"
+    ]
+
+    puts "Hunting for the hanging regex in #{target_file}...\n\n"
+
+    rules.each do |rule_name|
+      full_rule = "#{style_prefix}.#{rule_name}"
+      print "Testing #{full_rule}... "
+      filter_string = ".Name=='#{full_rule}'"
+
+      # Run Vale for just this single rule
+      IO.popen(["vale", "--filter=#{filter_string}", "--output=line", target_file]) do |io|
+        begin
+          # If the regex loops catastrophically, it hits this 5-second limit
+          Timeout.timeout(5) do
+            io.read
+          end
+
+          # If it finishes within 5 seconds, the rule is safe
+          puts "\e[32mPassed (No hang)\e[0m"
+
+        rescue Timeout::Error
+          # The regex froze! Kill the underlying process to save CPU and flag it
+          Process.kill("KILL", io.pid)
+          puts "\e[31m💥 HUNG! (This is the broken regex)\e[0m"
+        end
+      end
+    end
+
+    exit 0
+  end
+
 end


### PR DESCRIPTION
## Proposed changes

### What changed

The linting report runs without any output until the end, making it hard to know if it is running or timed out.  This adds output at each file and catches timeouts to output them as a failure.

There is also an additional debug task for running locally

## Related issue or tracking reference

> If there is no issue, please open one or please explain why one is not needed (for example small maintenance change, routine dependency update).

There is no open issue, this isas a result of the latest linter updates causing timeouts in the example documentation site


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [ ] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed